### PR TITLE
Test vectors

### DIFF
--- a/draft-protected-headers.md
+++ b/draft-protected-headers.md
@@ -315,7 +315,7 @@ A MUA SHOULD transform a Cryptographic Payload to include a Legacy Display part 
 Additionally, if the sender knows that the recipient's MUA is capable of interpreting Protected Headers, it SHOULD NOT attempt to include a Legacy Display part.
 (Signalling such a capability is out of scope for this document)
 
-Message Rendering: Omitting a Legacy Display Part
+Message Rendering: Omitting a Legacy Display Part {#no-render-legacy-display}
 -------------------------------------------------
 
 A MUA that understands Protected Headers may receive an encrypted message that contains a Legacy Display part.
@@ -839,7 +839,7 @@ noY9JG+8I1rxMH5CpskA+wXacRQ/xoDjwEBL671CDDXYTi/QiOK5vA64gUxDbE0L
 --904b809781--
 ~~~
 
-Encrypted Message with Protected Headers
+Encrypted Message with Protected Headers {#encryptedsigned}
 ----------------------------------------
 
 This shows a simple encrypted message with protected headers.  Its MIME message structure is:
@@ -858,6 +858,8 @@ Such an attacker would know details about Alice and Bob's business that they wan
 The protected headers also protect the authenticity of subject line as well.
 
 The session key for this message's crypto layer is an AES-256 key with value `8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2` (in hex).
+
+If Bob's MUA is capable of interpreting these protected headers, it should render the `Subject:` of this message as `BarCorp contract signed, let's go!`.
 
 ~~~
 Received: from localhost (localhost [127.0.0.1]);
@@ -914,8 +916,79 @@ ACZcaqsLro8SNaJdSCrFVxmuqN+h4JO8ppso5wRwPLErVPpIlC5RpDM=
 Encrypted Message with Protected Headers and Legacy Display Part
 ----------------------------------------------------------------
 
-FIXME need to fill this in...
+If Alice's MUA wasn't sure whether Bob's MUA would know to render the obscured `Subject:` header correctly, it might include a legacy display part in the cryptographic payload.
 
+This message is structured in the following way:
+
+    └┬╴multipart/encrypted
+     ├─╴application/pgp-encrypted
+     └─╴application/octet-stream
+       ↧ (decrypts to)
+       └┬╴multipart/mixed
+        ├─╴text/rfc822-headers
+        └─╴text/plain
+
+The example below shows the same message as {{encryptedsigned}}.
+
+If Bob's MUA is capable of handling protected headers, the two messages should render in the same way as the message in {{encryptedsigned}}, because it will know to omit the Legacy Display part as documented in {{no-render-legacy-display}}.
+
+But if Bob's MUA is capable of decryption but is unaware of protected headers, it will likely render the Legacy Display part for him so that he can at least see the originally-intended `Subject:` line.
+
+For this message, the session key is an AES-256 key with value `95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e` (in hex).
+
+~~~
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="73c8655345";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <signed+encrypted+legacy-display@protected-headers.example>
+Subject: ...
+
+--73c8655345
+Content-Type: application/pgp-encrypted; charset="us-ascii"
+
+Version: 1
+
+--73c8655345
+Content-Type: application/octet-stream; charset="us-ascii"
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdAHI4CaIxAXy7Iv16FZmMd/p+T+KWEwxDrllVS8jkNCWcw
+HTyfe2pnyOw3NPuwEDXcvLKTl/LC6MonWW1t91MqRnnzpUN3Kdb7gAMrmN5RMstH
+wcDMA3wvqk35PDeyAQv+NwDQfyY5BFZRI99aphwLI1lfKTg8Tx6Y8ajVHD0x4Ton
+hXnBwwMLO5BSn5/cgqFt/mhNVmILNiv4IrK+alwOLkBw6M0+F0iUiu1w1KrB+PdJ
+a8N038mKIAH3SdMTi7ryTyUq2+Hl44AVNWKmFdwesAE7b3cA1g1ZztGE1GV+WD8B
+qGd2IsB09CnkxGgoRb71xjV3ZJ3X7qvWP6B9W7eaM0vLyxA0ap2cJdkv1pGEZhch
+iEtVxmsJrXaQqjf2TJeV4bD8hfdCUpoiE07eFwWN2xBRh0lcN45QXWgpfOBsvLQ9
+Cn6vLb4IQStrhe+oNN90bzNZtAv+odvWLDW0hKP/7TkxncK4MHg/uZO45yLKpdis
+azNgAp8IbLjZ9mPodzZB035OZ+iS6KEEwo/zI/miqX4QtEpuCXIYnTsERoTTNUw7
+EJSZ+RpO0L1jGOQgqlFh+h1zLlvlnphdH72hhPHRcyY4hqQG5gGTWCHl0OA8LMlv
+0s+nYNcbIbJdV4b6s/GL0sIpAcA5Bo/Eu0hC8eXQDJMoQYk3sXhzU5LYu/V5Gn51
+BKPWzTkz+mfvTRkTb/LC8QKifm+kOg/D/IUKT87Ep1yb2on8pj789QkQUSUqO5Hc
+Hp3IElZXSKTUdvpzlQi6UzBRhTV6FqZJtzifQL3HuGPYbv3UwXrQIsA3Cqhm6KL+
+u7BVmXFlhk1Liul59zQs4RfMMHZww8Ios5r7Aib/Trp/Oyyu4erJnLjaip14+amJ
+oDF7L2sln/l9t9YtkkXKwhjsLWnfb/6JL6+MixCrTxGUG/N8TT0O8MvzeLRUiPm0
+GLHcTT9R6kO1+1BDsKpBlzChzSeHkH30lkQ6dPkv/C5D7if5f9r+UcIUuO//SEH8
+XYFjAyhi/HSZONgshmWebZxhN5AVR6qbl84/wowJf9xOpfbiW1Vdg+7gQ3m7RFPh
+/1AoC2NDkOWKo70ctEzDtnbRPUNa9aaptjJYKWKvURDhaQ5yVz/A7Wr/cmks+FMp
+S8HAdBH8+I//5OPVJHgeuO004b8YzADawajm4u7rL7nccaPCFbAZXIoX/78XNqRw
+TJGwE8MPu5w3b8d4fKk++PDHVnvIyofo7n2ST+SAS4/KI+VOlAhXmNdkxhKIEHKk
+HUPB2zeEoGVFecRIdMm5dVLtf9EOBE8QZvQnxiYN05TQ9ECaJ0ONWRjYCC8EiRme
+gzIOpjIlw81JG+m9yGDp0S7iN5UJCCiolLJy2rPIBxWpJSwALRHy2u46VGyHONfX
+VRfKSZuBwu/kkfDHmw/I7aN8JNWiIrYhaPZ3vuGZ1ZWGtxbgvUlD9lZWG6+UM9+k
+6RF3YLZKXGkJzzh9ipKZFgnWgyOSvRQzMtWSj8GSdKAXRQgQUdYg82jCe2IKYQdf
+UGy7MjEvOJTTHKvMkIuBFrQpPWklWAN4XFAf4m2iciHw/f2WxJ/Nj2HET+OxmFMD
+mZ/z90MZ2jBxCO4Rug18yFC5CsHlt6SeaPPw9GtER7J2YAcE7SXb3iXXqw==
+=9CTX
+-----END PGP MESSAGE-----
+
+--73c8655345--
+~~~
 
 IANA Considerations
 ===================

--- a/draft-protected-headers.md
+++ b/draft-protected-headers.md
@@ -839,6 +839,84 @@ noY9JG+8I1rxMH5CpskA+wXacRQ/xoDjwEBL671CDDXYTi/QiOK5vA64gUxDbE0L
 --904b809781--
 ~~~
 
+Encrypted Message with Protected Headers
+----------------------------------------
+
+This shows a simple encrypted message with protected headers.  Its MIME message structure is:
+
+    └┬╴multipart/encrypted
+     ├─╴application/pgp-encrypted
+     └─╴application/octet-stream
+       ↧ (decrypts to)
+       └─╴text/plain
+
+The `Subject:` header is successfully obscured.
+
+Note that if this message had been generated without Protected Headers, then an attacker with access to it could have read Subject.
+Such an attacker would know details about Alice and Bob's business that they wanted to keep confidential.
+
+The protected headers also protect the authenticity of subject line as well.
+
+The session key for this message's crypto layer is an AES-256 key with value `8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2` (in hex).
+
+~~~
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="bcde3ce988";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <signed+encrypted@protected-headers.example>
+Subject: ...
+
+--bcde3ce988
+Content-Type: application/pgp-encrypted; charset="us-ascii"
+
+Version: 1
+
+--bcde3ce988
+Content-Type: application/octet-stream; charset="us-ascii"
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdA8sJB4yKldNgJl9n0ETWERq8xapTZNCECEIdT8rU62Wgw
+zxU9dwhuamBCF81fXDf/qlLd+gi6xYxhqNpnEJU48vaoq8iyUymU1eKowQ/pnKA5
+wcDMA3wvqk35PDeyAQv/a7KZ3aMmf4tqk4VlKPd6l5+JTx8Mb2cu7E++xXqAjMdr
+vAOzpvAj4qzPwWyVe+ygIqcJYg0EAMiPkD/zMhWtn3rAh3/iAHRKcMIMblS4EEnR
+ykG04jfQ73bpX4J/YLTFBNnUMF/+t3tt2xJzo5YX5jUby01J9qMz8GA2SWuNSiN/
+LWtPXp13ShqHwX5DDtE+M7Od2ApEzSBo6Uj2lqIdCs+i4u/35HRPGIrTefED5ecB
+eL4ybuZdxwta+F0QFBQ0HO8R8uio1u7xCyx/KTRejpllG8FVRkiRD3QRf0N+7d7U
+T/etRm0VhR2zYhQPEfGVr8hQ/ZSWme5QEsFkMZRJIB+/KDXn/8wdcE/Jqs+yj+hr
+XwAoxGuiN6JagrQDe9RWEZt4cmAwSQzDY8ai/4WLd8sJOssx5LwUEW92ZclLd82X
+CLR1RoOLNOxfArwoPiTJiXxgUfIZjmOAlamIGUPtZCFkYeItYFnCiDaalfCwrJX8
+j4kzAX3p/qPEdK4QWBxS0sHHASVlm4xktQ1Z2IzB7GX2h3oVK8NdzrUZEYc80+ed
+pL8mEGerujQHTtCNFPU9A2NqcriLwYg9kMDMtyk/o8tL3LHIXolOod7kVGCCAWJ8
+tPRggmVi5Ly0tPNRDU5HJDHz0kINhd3InBvUZpoiNTZrtAnmIhKgE/Fn/4bGrY0H
+UGoAGyVbs5SifNmqP9GNXEqov+h4MchzWs5hn2Vj5jnjc8+cXXJhHU/b84QHPLmN
+vLFZLq71+3gC8XM1QktYctPhI4oesD9kuCCaEbKZbqs6Cagyl8lSslMB0VyNiAVp
+niJ2AL1+bHOUjO1SFn8EQyKjKHD1Wsbc7wwuSRi1ukzTaO3g6PHmwyhoxE/RZp0D
+OZkV3rdKEtPjh0d57SW6cIPm72UX6c2HjWKHEakX9dLTc3OS8vDtBRfUGOwcrlcN
+w/Q4qte1daqUTEpcldEY03pe+VbWtprCuM192clHqvTY0UNFfaEP+ZiJrj9toaGZ
+lqo6eZS/DOdywgOFuZkfsLcAYk/PhBLTle9t5R7jMd4PflX59uGQCytQsiat/nJl
+KAd7zF8cXrxEzAISt/WKlsbGaZo371BQc2JuAr3zFUdR9HWu1knlJsUFgm4x65RK
+pqryozyQy2zUt61lisMvm6qmo6TWzrDqCK1PDHaNRO2WRFOGxAAGc1Ypa/UPCXrL
+jfpU13eh1fiNwmhWlT3/0IH0JXY5wSjCXiHTBRjMr/5pN70wXX14xDOirOoj45ef
+j2eVi38yIkT6m/vrYJxUoahQZTl0gK+hExIYXftR9BXf50I23vAspwRCE5c+RRnt
+ACZcaqsLro8SNaJdSCrFVxmuqN+h4JO8ppso5wRwPLErVPpIlC5RpDM=
+=CatE
+-----END PGP MESSAGE-----
+
+--bcde3ce988--
+~~~
+
+Encrypted Message with Protected Headers and Legacy Display Part
+----------------------------------------------------------------
+
+FIXME need to fill this in...
+
+
 IANA Considerations
 ===================
 

--- a/draft-protected-headers.md
+++ b/draft-protected-headers.md
@@ -787,7 +787,11 @@ They are provided in textual source form as {{RFC2822}} messages.
 Signed Message with Protected Headers {#test-vector-signed-only}
 -------------------------------------
 
-This shows a clearsigned message.
+This shows a clearsigned message.  Its MIME message structure is:
+
+    └┬╴multipart/signed
+     ├─╴text/plain
+     └─╴application/pgp-signature
 
 Note that if this message had been generated without Protected Headers, then an attacker with access to it could modify the Subject without invalidating the signature.
 Such an attacker could cause Bob to think that Alice wanted to cancel the contract with BarCorp instead of FooCorp.

--- a/draft-protected-headers.md
+++ b/draft-protected-headers.md
@@ -774,6 +774,64 @@ But it does not offer confidentiality protection for the protected headers, and 
 In practice on today's Internet, DKIM ({{RFC6736}} provides a more widely-accepted cryptographic header-verification-for-transport mechanism  than triple-wrapped messages.
 
 
+Test Vectors
+============
+
+The subsections below provide example messages that implement the Protected Header scheme.
+
+They are provided in textual source form as {{RFC2822}} messages.
+
+Signed Message with Protected Headers {#test-vector-signed-only}
+-------------------------------------
+
+This shows a clearsigned message.
+
+Note that if this message had been generated without Protected Headers, then an attacker with access to it could modify the Subject without invalidating the signature.
+Such an attacker could cause Bob to think that Alice wanted to cancel the contract with BarCorp instead of FooCorp.
+
+~~~
+Received: from localhost (localhost [127.0.0.1]);
+ Sun, 20 Oct 2019 09:18:28 -0400 (UTC-04:00)
+MIME-Version: 1.0
+Content-Type: multipart/signed; boundary="904b809781";
+ protocol="application/pgp-signature"; micalg="pgp-sha512"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Sun, 20 Oct 2019 09:18:11 -0400
+Subject: The FooCorp contract
+Message-ID: <signed-only@protected-headers.example>
+
+--904b809781
+Content-Type: text/plain; charset="us-ascii"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Sun, 20 Oct 2019 09:18:11 -0400
+Subject: The FooCorp contract
+Message-ID: <signed-only@protected-headers.example>
+
+Bob, we need to cancel this contract.
+
+Please start the necessary processes to make that happen today.
+
+Thanks, Alice
+-- 
+Alice Lovelace
+President
+OpenPGP Example Corp
+
+--904b809781
+Content-Type: application/pgp-signature; charset="us-ascii"
+
+-----BEGIN PGP SIGNATURE-----
+
+wl4EARYKAAYFAl2sXpMACgkQ8jFVDE9H444uYwD/TpkvOT+KNMAzk00kkFM0/W/n
+noY9JG+8I1rxMH5CpskA+wXacRQ/xoDjwEBL671CDDXYTi/QiOK5vA64gUxDbE0L
+=1tUZ
+-----END PGP SIGNATURE-----
+
+--904b809781--
+~~~
+
 IANA Considerations
 ===================
 

--- a/draft-protected-headers.md
+++ b/draft-protected-headers.md
@@ -43,6 +43,7 @@ informative:
     target: https://autocrypt.org/level1.html
     title: Autocrypt Specification 1.1
     date: 2019-10-13
+ I-D.draft-bre-openpgp-samples-00:
  I-D.draft-luck-lamps-pep-header-protection-03:
  I-D.draft-ietf-lamps-header-protection-requirements-00:
  RFC2634:
@@ -778,6 +779,8 @@ Test Vectors
 ============
 
 The subsections below provide example messages that implement the Protected Header scheme.
+
+The secret keys and OpenPGP certificates from {{I-D.draft-bre-openpgp-samples-00}} can be used to decrypt and verify them.
 
 They are provided in textual source form as {{RFC2822}} messages.
 

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -19,7 +19,7 @@ import codecs
 import pgpy
 
 def usage(to=sys.stdout):
-    print(f'Usage: {sys.argv[0]} [help|sign|sign+encrypt]', file=to)
+    print(f'Usage: {sys.argv[0]} [help|sign|sign+encrypt|sign+encrypt+legacy]', file=to)
 
 # We want maxheaderlen=72 here so that the example fits nicely
 # in an Internet Draft.  But it is risky -- i think it could
@@ -159,7 +159,7 @@ OpenPGP Example Corp''')
     return msg
 
 
-def signed_encrypted():
+def signed_encrypted(legacy=False):
     # seconds since the unix epoch
     posixtime = 1571667491
     # America/Los_Angeles during DST:
@@ -199,19 +199,48 @@ OpenPGP Example Corp''')
     payload.set_charset('us-ascii') # the test vector data is 7-bit clean
     del payload['MIME-Version'] # MIME-Version on subparts is meaningless
     del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+
+    subj = 'BarCorp contract signed, let\'s go!'
+
+    msgid_rider = ''
+    # never do this! we only do it for a repeatable session key:
+    sessionkey = b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2'
+
+    if legacy:
+        sessionkey = b'95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e'
+        msgid_rider = '+legacy-display'
+
+        legacydisplay = email.message.MIMEPart()
+        legacydisplay.set_content(f'Subject: {subj}\n')
+        legacydisplay.set_type('text/rfc822-headers')
+        legacydisplay.set_param('protected-headers', 'v1')
+        legacydisplay.set_charset('us-ascii') # header data is always 7-bit clean
+        del legacydisplay['MIME-Version'] # MIME-Version on subparts is meaningless
+        del legacydisplay['Content-Transfer-Encoding'] # header data is always 7-bit clean
+        legacydisplay['Content-Disposition'] = 'inline'
+    
+        innerpayload = payload
+        payload = email.message.MIMEPart()
+        payload.set_type('multipart/mixed')
+        del legacydisplay['MIME-Version'] # MIME-Version on subparts is meaningless
+        # arbitrary fixed boundary for replicability:
+        payload.set_boundary(hashlib.sha256('legacy-wrapper'.encode()).hexdigest()[:10])
+        payload.attach(legacydisplay)
+        payload.attach(innerpayload)
+    
     # place intended headers on the payload:
     payload['From'] = f'{alice_key.userids[0].name} <{alice_key.userids[0].email}>'
     payload['To'] = f'{bob_key.userids[0].name} <{bob_key.userids[0].email}>'
     payload['Date'] = whenstring
-    payload['Subject'] = 'BarCorp contract signed, let\'s go!'
-    payload['Message-ID'] = '<signed+encrypted@protected-headers.example>'
+    payload['Subject'] = subj
+
+    sessionkey = codecs.decode(sessionkey, 'hex')
+    payload['Message-ID'] = f'<signed+encrypted{msgid_rider}@protected-headers.example>'
     payloadmsg = pgpy.PGPMessage.new(str(payload), format='m')
     # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
     # in order for the signature creation time to match the message Date header:
     payloadmsg |= alice_key.sign(payloadmsg, created=when)
     cipher = pgpy.constants.SymmetricKeyAlgorithm.AES256
-    # never do this! we only do it for a repeatable session key:
-    sessionkey = codecs.decode(b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2', 'hex')
 
     encmsg = alice_key.pubkey.encrypt(payloadmsg, cipher=cipher, sessionkey=sessionkey)
     encmsg = bob_key.encrypt(encmsg, cipher=cipher, sessionkey=sessionkey)
@@ -259,7 +288,9 @@ if __name__ == '__main__':
     elif sys.argv[1] == 'sign':
         print(signed().as_string(maxheaderlen=MAXHEADERLEN))
     elif sys.argv[1] == 'sign+encrypt':
-        print(signed_encrypted().as_string(maxheaderlen=MAXHEADERLEN))
+        print(signed_encrypted(False).as_string(maxheaderlen=MAXHEADERLEN))
+    elif sys.argv[1] == 'sign+encrypt+legacy':
+        print(signed_encrypted(True).as_string(maxheaderlen=MAXHEADERLEN))
     else:
         print(f'Unknown argument "{sys.argv[1]}"', file=sys.stderr)
         usage(to=sys.stderr)

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -14,12 +14,19 @@ import email.message
 import email.policy
 import hashlib
 import sys
+import codecs
 
 import pgpy
 
 def usage(to=sys.stdout):
-    print(f'Usage: {sys.argv[0]} [help|sign]', file=to)
+    print(f'Usage: {sys.argv[0]} [help|sign|sign+encrypt]', file=to)
 
+# We want maxheaderlen=72 here so that the example fits nicely
+# in an Internet Draft.  But it is risky -- i think it could
+# break a signed message with long headers.  We get away with
+# it because our Cryptographic Payload is already narrow.
+MAXHEADERLEN=72
+    
 # from https://tools.ietf.org/html/draft-bre-openpgp-samples-00#section-2.2:
 alice_sec = '''-----BEGIN PGP PRIVATE KEY BLOCK-----
 Comment: Alice's OpenPGP Transferable Secret Key
@@ -38,8 +45,53 @@ Pnn+We1aTBhaGa86AQ==
 =n8OM
 -----END PGP PRIVATE KEY BLOCK-----
 '''
-
 (alice_key, _) = pgpy.PGPKey.from_blob(alice_sec)
+
+# from https://tools.ietf.org/html/draft-bre-openpgp-samples-00#section-3.1:
+bob_pub = '''-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Bob's OpenPGP certificate
+
+mQGNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv
+/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz
+/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/
+5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3
+X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv
+9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0
+qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb
+SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb
+vLIwa3T4CyshfT0AEQEAAbQhQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w
+bGU+iQHOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx
+gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz
+XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO
+ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g
+9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF
+DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c
+ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1
+6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ
+ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo
+zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGuQGNBF2lnPIBDADW
+ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI
+DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+
+Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO
+baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT
+86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh
+827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6
+vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U
+qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A
+EQEAAYkBtgQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJdpZzyAhsMAAoJ
+EPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQMw7+41IL4rVcS
+KhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUrdVaZQanYmtSx
+cVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMVV9zpf3u0k14i
+tcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZgbYn3OWjCPHV
+dTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8/5VK2b0vk/+w
+qMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8AyFAExaEK6Vy
+jP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUCBqWif9RSK4xj
+zRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4ubVrj5KjhX2PV
+NEJd3XZRzaXZE2aAMQ==
+=NXei
+-----END PGP PUBLIC KEY BLOCK-----
+'''
+(bob_key, _) = pgpy.PGPKey.from_blob(bob_pub)
 
 def signed():
     # seconds since the unix epoch
@@ -72,7 +124,7 @@ OpenPGP Example Corp''')
     del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
     # place intended headers on the payload:
     payload['From'] = f'{alice_key.userids[0].name} <{alice_key.userids[0].email}>'
-    payload['To'] = 'Bob Babbage <bob@openpgp.example>'
+    payload['To'] = f'{bob_key.userids[0].name} <{bob_key.userids[0].email}>'
     payload['Date'] = whenstring
     payload['Subject'] = 'The FooCorp contract'
     payload['Message-ID'] = '<signed-only@protected-headers.example>'
@@ -106,6 +158,98 @@ OpenPGP Example Corp''')
                 msg[h] = payload[h]
     return msg
 
+
+def signed_encrypted():
+    # seconds since the unix epoch
+    posixtime = 1571667491
+    # America/Los_Angeles during DST:
+    tz = datetime.timezone(datetime.timedelta(hours=-7))
+    # 2019-10-21T07:18:11-0700
+    when = datetime.datetime.fromtimestamp(posixtime, tz)
+    whenstring = when.strftime('%a, %d %b %Y %T %z').strip()
+
+    # message was received 28 seconds after it was generated:
+    rcvd = datetime.datetime.fromtimestamp(posixtime + 28, tz)
+    rcvdstring = rcvd.strftime('%a, %d %b %Y %T %z (%Z)').strip()
+
+    # make the Cryptographic Payload:
+    payload = email.message.MIMEPart()
+    dotsig_separator = '-- ' # this is a totally different kind of "signature"
+    payload.set_content(f'''Hi Bob!
+
+I just signed the contract with BarCorp and they've set us up with an account
+on their system for testing.
+
+The account information is:
+
+        Site: https://barcorp.example/
+    Username: examplecorptest
+    Password: correct-horse-battery-staple
+
+Please get the account set up and apply the test harness.
+
+Let me know when you've got some results.
+
+Thanks, Alice
+{dotsig_separator}
+Alice Lovelace
+President
+OpenPGP Example Corp''')
+    payload.set_type('text/plain')
+    payload.set_charset('us-ascii') # the test vector data is 7-bit clean
+    del payload['MIME-Version'] # MIME-Version on subparts is meaningless
+    del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+    # place intended headers on the payload:
+    payload['From'] = f'{alice_key.userids[0].name} <{alice_key.userids[0].email}>'
+    payload['To'] = f'{bob_key.userids[0].name} <{bob_key.userids[0].email}>'
+    payload['Date'] = whenstring
+    payload['Subject'] = 'BarCorp contract signed, let\'s go!'
+    payload['Message-ID'] = '<signed+encrypted@protected-headers.example>'
+    payloadmsg = pgpy.PGPMessage.new(str(payload), format='m')
+    # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
+    # in order for the signature creation time to match the message Date header:
+    payloadmsg |= alice_key.sign(payloadmsg, created=when)
+    cipher = pgpy.constants.SymmetricKeyAlgorithm.AES256
+    # never do this! we only do it for a repeatable session key:
+    sessionkey = codecs.decode(b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2', 'hex')
+
+    encmsg = alice_key.pubkey.encrypt(payloadmsg, cipher=cipher, sessionkey=sessionkey)
+    encmsg = bob_key.encrypt(encmsg, cipher=cipher, sessionkey=sessionkey)
+
+    encpart = email.message.MIMEPart()
+    encpart.set_content(str(encmsg))
+    encpart.set_type('application/octet-stream')
+    encpart.set_charset('us-ascii') # encrypted body is ASCII-armored already
+    del encpart['MIME-Version'] # MIME-Version on subparts is meaningless
+    del encpart['Content-Transfer-Encoding'] # ASCII-armored data is 7-bit clean
+
+    cruft = email.message.MIMEPart()
+    cruft.set_content('Version: 1')
+    cruft.set_type('application/pgp-encrypted')
+    cruft.set_charset('us-ascii') # the cruft data is 7-bit clean by definition
+    del cruft['MIME-Version'] # MIME-Version on subparts is meaningless
+    del cruft['Content-Transfer-Encoding'] # the cruft data is 7-bit clean by definition
+    
+    msg = email.message.Message()
+    # Example transit header that is not part of the protected headers:
+    msg['Received'] = f'from localhost (localhost [127.0.0.1]); {rcvdstring}'
+    msg.set_type('multipart/encrypted')
+    # making up an arbitrary MIME boundary based on the Message-ID:
+    msg.set_boundary(hashlib.sha256(payload['Message-ID'].encode()).hexdigest()[:10])
+    msg.set_param('protocol', 'application/pgp-encrypted')
+    msg.attach(cruft)
+    msg.attach(encpart)
+
+    # ensure that all non-Content headers from the payload are also on
+    # the message:
+    for h in payload.keys():
+        if not h.lower().startswith('content-'): # don't transfer Content-* headers
+            if h.lower() != 'subject': # we will obscure Subject line
+                if msg.get(h, None) != payload[h]: # don't duplicate headers that already exist
+                    msg[h] = payload[h]
+    msg['Subject'] = '...'
+    return msg
+
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         usage(to=sys.stderr)
@@ -113,11 +257,9 @@ if __name__ == '__main__':
     if sys.argv[1] == 'help':
         usage()
     elif sys.argv[1] == 'sign':
-        # We want maxheaderlen=72 here so that the example fits nicely
-        # in an Internet Draft.  But it is risky -- i think it could
-        # break a signed message with long headers.  We get away with
-        # it because our Cryptographic Payload is already narrow.
-        print(signed().as_string(maxheaderlen=72))
+        print(signed().as_string(maxheaderlen=MAXHEADERLEN))
+    elif sys.argv[1] == 'sign+encrypt':
+        print(signed_encrypted().as_string(maxheaderlen=MAXHEADERLEN))
     else:
         print(f'Unknown argument "{sys.argv[1]}"', file=sys.stderr)
         usage(to=sys.stderr)

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -1,0 +1,124 @@
+#!/usr/bin/python3
+'''Deterministically generate test vectors for draft-protected-headers.
+
+We want each run to produce the same specific output, which means
+hard-coding things (like timestamps, time zones, MIME boundaries,
+message-ids) which are likely to be vary across real-world conditions.
+
+Pains are taken to minimize the total amount of output, while still
+preserving a plausible, minimal, correctly-formed message.
+'''
+
+import datetime
+import email.message
+import email.policy
+import hashlib
+import sys
+
+import pgpy
+
+def usage(to=sys.stdout):
+    print(f'Usage: {sys.argv[0]} [help|sign]', file=to)
+
+# from https://tools.ietf.org/html/draft-bre-openpgp-samples-00#section-2.2:
+alice_sec = '''-----BEGIN PGP PRIVATE KEY BLOCK-----
+Comment: Alice's OpenPGP Transferable Secret Key
+
+lFgEXEcE6RYJKwYBBAHaRw8BAQdArjWwk3FAqyiFbFBKT4TzXcVBqPTB3gmzlC/U
+b7O1u10AAP9XBeW6lzGOLx7zHH9AsUDUTb2pggYGMzd0P3ulJ2AfvQ4RtCZBbGlj
+ZSBMb3ZlbGFjZSA8YWxpY2VAb3BlbnBncC5leGFtcGxlPoiQBBMWCAA4AhsDBQsJ
+CAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE64W7X6M6deFelE5j8jFVDE9H444FAl2l
+nzoACgkQ8jFVDE9H447pKwD6A5xwUqIDprBzrHfahrImaYEZzncqb25vkLV2arYf
+a78A/R3AwtLQvjxwLDuzk4dUtUwvUYibL2sAHwj2kGaHnfICnF0EXEcE6RIKKwYB
+BAGXVQEFAQEHQEL/BiGtq0k84Km1wqQw2DIikVYrQrMttN8d7BPfnr4iAwEIBwAA
+/3/xFPG6U17rhTuq+07gmEvaFYKfxRB6sgAYiW6TMTpQEK6IeAQYFggAIBYhBOuF
+u1+jOnXhXpROY/IxVQxPR+OOBQJcRwTpAhsMAAoJEPIxVQxPR+OOWdABAMUdSzpM
+hzGs1O0RkWNQWbUzQ8nUOeD9wNbjE3zR+yfRAQDbYqvtWQKN4AQLTxVJN5X5AWyb
+Pnn+We1aTBhaGa86AQ==
+=n8OM
+-----END PGP PRIVATE KEY BLOCK-----
+'''
+
+(alice_key, _) = pgpy.PGPKey.from_blob(alice_sec)
+
+def signed():
+    # seconds since the unix epoch
+    posixtime = 1571577491
+    # America/New_York during DST:
+    tz = datetime.timezone(datetime.timedelta(hours=-4))
+    # 2019-10-20T09:18:11-0400
+    when = datetime.datetime.fromtimestamp(posixtime, tz)
+    whenstring = when.strftime('%a, %d %b %Y %T %z').strip()
+
+    # message was received 17 seconds after it was generated:
+    rcvd = datetime.datetime.fromtimestamp(posixtime + 17, tz)
+    rcvdstring = rcvd.strftime('%a, %d %b %Y %T %z (%Z)').strip()
+
+    # make the Cryptographic Payload:
+    payload = email.message.MIMEPart()
+    dotsig_separator = '-- ' # this is a totally different kind of "signature"
+    payload.set_content(f'''Bob, we need to cancel this contract.
+
+Please start the necessary processes to make that happen today.
+
+Thanks, Alice
+{dotsig_separator}
+Alice Lovelace
+President
+OpenPGP Example Corp''')
+    payload.set_type('text/plain')
+    payload.set_charset('us-ascii') # the test vector data is 7-bit clean
+    del payload['MIME-Version'] # MIME-Version on subparts is meaningless
+    del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+    # place intended headers on the payload:
+    payload['From'] = f'{alice_key.userids[0].name} <{alice_key.userids[0].email}>'
+    payload['To'] = 'Bob Babbage <bob@openpgp.example>'
+    payload['Date'] = whenstring
+    payload['Subject'] = 'The FooCorp contract'
+    payload['Message-ID'] = '<signed-only@protected-headers.example>'
+
+    sigpart = email.message.MIMEPart()
+    # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
+    # in order for the signature creation time to match the message Date header:
+    pgpsig = alice_key.sign(pgpy.PGPMessage.new(str(payload), cleartext=True), created=when)
+    sigpart.set_content(str(pgpsig).strip())
+    sigpart.set_type('application/pgp-signature')
+    sigpart.set_charset('us-ascii') # the test vector data is 7-bit clean
+    del sigpart['MIME-Version'] # MIME-Version on subparts is meaningless
+    del sigpart['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+
+    msg = email.message.Message()
+    # Example transit header that is not part of the protected headers:
+    msg['Received'] = f'from localhost (localhost [127.0.0.1]); {rcvdstring}'
+    msg.set_type('multipart/signed')
+    # making up an arbitrary MIME boundary based on the Message-ID:
+    msg.set_boundary(hashlib.sha256(payload['Message-ID'].encode()).hexdigest()[:10])
+    msg.set_param('protocol', 'application/pgp-signature')
+    msg.set_param('micalg', f'pgp-{pgpsig.hash_algorithm.name.lower()}')
+    msg.attach(payload)
+    msg.attach(sigpart)
+
+    # ensure that all non-Content headers from the payload are also on
+    # the message:
+    for h in payload.keys():
+        if not h.lower().startswith('content-'): # don't transfer Content-* headers
+            if msg.get(h, None) != payload[h]: # don't duplicate headers that already exist
+                msg[h] = payload[h]
+    return msg
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        usage(to=sys.stderr)
+        exit(1)
+    if sys.argv[1] == 'help':
+        usage()
+    elif sys.argv[1] == 'sign':
+        # We want maxheaderlen=72 here so that the example fits nicely
+        # in an Internet Draft.  But it is risky -- i think it could
+        # break a signed message with long headers.  We get away with
+        # it because our Cryptographic Payload is already narrow.
+        print(signed().as_string(maxheaderlen=72))
+    else:
+        print(f'Unknown argument "{sys.argv[1]}"', file=sys.stderr)
+        usage(to=sys.stderr)
+        exit(1)

--- a/test-notmuch
+++ b/test-notmuch
@@ -44,9 +44,106 @@ DAAKCRDyMVUMT0fjjlnQAQDFHUs6TIcxrNTtEZFjUFm1M0PJ1Dng/cDW4xN80fsn
 =iIGO
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
+# from https://tools.ietf.org/html/draft-bre-openpgp-samples-00#section-3.2:
+gpg --batch --quiet --no-tty --import <<EOF
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+Comment: Bob's OpenPGP Transferable Secret Key
+
+lQVYBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv
+/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz
+/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/
+5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3
+X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv
+9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0
+qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb
+SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb
+vLIwa3T4CyshfT0AEQEAAQAL/RZqbJW2IqQDCnJi4Ozm++gPqBPiX1RhTWSjwxfM
+cJKUZfzLj414rMKm6Jh1cwwGY9jekROhB9WmwaaKT8HtcIgrZNAlYzANGRCM4TLK
+3VskxfSwKKna8l+s+mZglqbAjUg3wmFuf9Tj2xcUZYmyRm1DEmcN2ZzpvRtHgX7z
+Wn1mAKUlSDJZSQks0zjuMNbupcpyJokdlkUg2+wBznBOTKzgMxVNC9b2g5/tMPUs
+hGGWmF1UH+7AHMTaS6dlmr2ZBIyogdnfUqdNg5sZwsxSNrbglKP4sqe7X61uEAIQ
+bD7rT3LonLbhkrj3I8wilUD8usIwt5IecoHhd9HziqZjRCc1BUBkboUEoyedbDV4
+i4qfsFZ6CEWoLuD5pW7dEp0M+WeuHXO164Rc+LnH6i1VQrpb1Okl4qO6ejIpIjBI
+1t3GshtUu/mwGBBxs60KBX5g77mFQ9lLCRj8lSYqOsHRKBhUp4qM869VA+fD0BRP
+fqPT0I9IH4Oa/A3jYJcg622GwQYA1LhnP208Waf6PkQSJ6kyr8ymY1yVh9VBE/g6
+fRDYA+pkqKnw9wfH2Qho3ysAA+OmVOX8Hldg+Pc0Zs0e5pCavb0En8iFLvTA0Q2E
+LR5rLue9uD7aFuKFU/VdcddY9Ww/vo4k5p/tVGp7F8RYCFn9rSjIWbfvvZi1q5Tx
++akoZbga+4qQ4WYzB/obdX6SCmi6BndcQ1QdjCCQU6gpYx0MddVERbIp9+2SXDyL
+hpxjSyz+RGsZi/9UAshT4txP4+MZBgDfK3ZqtW+h2/eMRxkANqOJpxSjMyLO/FXN
+WxzTDYeWtHNYiAlOwlQZEPOydZFty9IVzzNFQCIUCGjQ/nNyhw7adSgUk3+BXEx/
+MyJPYY0BYuhLxLYcrfQ9nrhaVKxRJj25SVHj2ASsiwGJRZW4CC3uw40OYxfKEvNC
+mer/VxM3kg8qqGf9KUzJ1dVdAvjyx2Hz6jY2qWCyRQ6IMjWHyd43C4r3jxooYKUC
+YnstRQyb/gCSKahveSEjo07CiXMr88UGALwzEr3npFAsPW3osGaFLj49y1oRe11E
+he9gCHFm+fuzbXrWmdPjYU5/ZdqdojzDqfu4ThfnipknpVUM1o6MQqkjM896FHm8
+zbKVFSMhEP6DPHSCexMFrrSgN03PdwHTO6iBaIBBFqmGY01tmJ03SxvSpiBPON9P
+NVvy/6UZFedTq8A07OUAxO62YUSNtT5pmK2vzs3SAZJmbFbMh+NN204TRI72GlqT
+t5hcfkuv8hrmwPS/ZR6q312mKQ6w/1pqO9qitCFCb2IgQmFiYmFnZSA8Ym9iQG9w
+ZW5wZ3AuZXhhbXBsZT6JAc4EEwEKADgCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgEC
+F4AWIQTRpm4aI7GCyZgPeIz7/MgqAV5zMAUCXaWe+gAKCRD7/MgqAV5zMG9sC/9U
+2T3RrqEbw533FPNfEflhEVRIZ8gDXKM8hU6cqqEzCmzZT6xYTe6sv4y+PJBGXJFX
+yhj0g6FDkSyboM5litOcTupURObVqMgA/Y4UKERznm4fzzH9qek85c4ljtLyNufe
+doL2pp3vkGtn7eD0QFRaLLmnxPKQ/TlZKdLE1G3u8Uot8QHicaR6GnAdc5UXQJE3
+BiV7jZuDyWmZ1cUNwJkKL6oRtp+ZNDOQCrLNLecKHcgCqrpjSQG5oouba1I1Q6Vl
+sP44dhA1nkmLHtxlTOzpeHj4jnk1FaXmyasurrrI5CgU/L2Oi39DGKTH/A/cywDN
+4ZplIQ9zR8enkbXquUZvFDe+Xz+6xRXtb5MwQyWODB3nHw85HocLwRoIN9WdQEI+
+L8a/56AuOwhs8llkSuiITjR7r9SgKJC2WlAHl7E8lhJ3VDW3ELC56KH308d6mwOG
+ZRAqIAKzM1T5FGjMBhq7ZV0eqdEntBh3EcOIfj2M8rg1MzJv+0mHZOIjByawikad
+BVgEXaWc8gEMANYwv1xsYyunXYK0X1vY/rP1NNPvhLyLIE7NpK90YNBj+xS1ldGD
+bUdZqZeef2xJe8gMQg05DoD1DF3GipZ0Ies65beh+d5hegb7N4pzh0LzrBrVNHar
+29b5ExdI7i4iYD5TO6Vr/qTUOiAN/byqELEzAb+L+b2DVz/RoCm4PIp1DU9ewcc2
+WB38Ofqut3nLYA5tqJ9XvAiEQme+qAVcM3ZFcaMt4I4dXhDZZNg+D9LiTWcxdUPB
+leu8iwDRjAgyAhPzpFp+nWoqWA81uIiULWD1Fj+IVoY3ZvgivoYOiEFBJ9lbb4te
+g9m5UT/AaVDTWuHzbspVlbiVe+qyB77C2daWzNyx6UYBPLOo4r0t0c91kbNE5lgj
+Z7xz6los0N1U8vq91EFSeQJoSQ62XWavYmlCLmdNT6BNfgh4icLsT7Vr1QMX9jzn
+JtTPxdXytSdHvpSpULsqJ016l0dtmONcK3z9mj5N5z0k1tg1AH970TGYOe2aUcSx
+IRDMXDOPyzEfjwARAQABAAv9F2CwsjS+Sjh1M1vegJbZjei4gF1HHpEM0K0PSXsp
+SfVvpR4AoSJ4He6CXSMWg0ot8XKtDuZoV9jnJaES5UL9pMAD7JwIOqZm/DYVJM5h
+OASCh1c356/wSbFbzRHPtUdZO9Q30WFNJM5pHbCJPjtNoRmRGkf71RxtvHBzy7np
+Ga+W6U/NVKHw0i0CYwMI0YlKDakYW3Pm+QL+gHZFvngGweTod0f9l2VLLAmeQR/c
++EZs7lNumhuZ8mXcwhUc9JQIhOkpO+wreDysEFkAcsKbkQP3UDUsA1gFx9pbMzT0
+tr1oZq2a4QBtxShHzP/ph7KLpN+6qtjks3xB/yjTgaGmtrwM8tSe0wD1RwXS+/1o
+BHpXTnQ7TfeOGUAu4KCoOQLv6ELpKWbRBLWuiPwMdbGpvVFALO8+kvKAg9/r+/ny
+zM2GQHY+J3Jh5JxPiJnHfXNZjIKLbFbIPdSKNyJBuazXW8xIa//mEHMI5OcvsZBK
+clAIp7LXzjEjKXIwHwDcTn9pBgDpdOKTHOtJ3JUKx0rWVsDH6wq6iKV/FTVSY5jl
+zN+puOEsskF1Lfxn9JsJihAVO3yNsp6RvkKtyNlFazaCVKtDAmkjoh60XNxcNRqr
+gCnwdpbgdHP6v/hvZY54ZaJjz6L2e8unNEkYLxDt8cmAyGPgH2XgL7giHIp9jrsQ
+aS381gnYwNX6wE1aEikgtY91nqJjwPlibF9avSyYQoMtEqM/1UjTjB2KdD/MitK5
+fP0VpvuXpNYZedmyq4UOMwdkiNMGAOrfmOeT0olgLrTMT5H97Cn3Yxbk13uXHNu/
+ZUZZNe8s+QtuLfUlKAJtLEUutN33TlWQY522FV0m17S+b80xJib3yZVJteVurrh5
+HSWHAM+zghQAvCesg5CLXa2dNMkTCmZKgCBvfDLZuZbjFwnwCI6u/NhOY9egKuUf
+SA/je/RXaT8m5VxLYMxwqQXKApzD87fv0tLPlVIEvjEsaf992tFEFSNPcG1l/jpd
+5AVXw6kKuf85UkJtYR1x2MkQDrqY1QX/XMw00kt8y9kMZUre19aCArcmor+hDhRJ
+E3Gt4QJrD9z/bICESw4b4z2DbgD/Xz9IXsA/r9cKiM1h5QMtXvuhyfVeM01enhxM
+GbOH3gjqqGNKysx0UODGEwr6AV9hAd8RWXMchJLaExK9J5SRawSg671ObAU24SdY
+vMQ9Z4kAQ2+1ReUZzf3ogSMRZtMT+d18gT6L90/y+APZIaoArLPhebIAGq39HLmJ
+26x3z0WAgrpA1kNsjXEXkoiZGPLKIGoe3hqJAbYEGAEKACAWIQTRpm4aI7GCyZgP
+eIz7/MgqAV5zMAUCXaWc8gIbDAAKCRD7/MgqAV5zMOn/C/9ugt+HZIwX308zI+QX
+c5vDLReuzmJ3ieE0DMO/uNSC+K1XEioSIZP91HeZJ2kbT9nn9fuReuoff0T0Dief
+rbwcIQQHFFkrqSp1K3VWmUGp2JrUsXFVdjy/fkBIjTd7c5boWljv/6wAsSfiv2V0
+JSM8EFU6TYXxswGjFVfc6X97tJNeIrXL+mpSmPPqy2bztcCCHkWS5lNLWQw+R7Vg
+71Fe6yBSNVrqC2/imYG2J9zlowjx1XU63Wdgqp2Wxt0l8OmsB/W80S1fRF5G4SDH
+s9HXglXXqPsBRZJYfP+VStm9L5P/sKjCcX6WtZR7yS6G8zj/X767MLK/djANvpPd
+NVniEke6hM3CNBXYPAMhQBMWhCulcoz+0lxi8L34rMN+Dsbma96psdUrn7uLaB91
+6we0CTfF8qqm7BsVAgalon/UUiuMY80U3ueoj3okiSTiHIjD/YtpXSPioC8nMng7
+xqAY9Bwizt4FWgXuLm1a4+So4V9j1TRCXd12Uc2l2RNmgDE=
+=miES
+-----END PGP PRIVATE KEY BLOCK-----
+EOF
 gpg --quiet --batch --no-tty --pinentry-mode=loopback --passphrase '' --quick-gen-key 'Local Test Suite Trust Anchor' futuredefault
 gpg --quiet --batch --no-tty --yes --lsign alice@openpgp.example
 notmuch new --quiet
-./generate-test-vectors.py sign | notmuch insert
+notmuch config set index.decrypt true
+./generate-test-vectors sign | notmuch insert
+./generate-test-vectors sign+encrypt | notmuch insert
+./generate-test-vectors sign+encrypt+legacy | notmuch insert
+notmuch count
 notmuch show --format=json --entire-thread=false --verify=true id:signed-only@protected-headers.example \
     | python3 -c 'import json,sys; json.dump(json.load(sys.stdin)[0][0][0]["crypto"], sys.stdout, indent=1)'
+echo
+notmuch show --format=json --entire-thread=false --verify=true id:signed+encrypted@protected-headers.example \
+    | python3 -c 'import json,sys; json.dump(json.load(sys.stdin)[0][0][0]["crypto"], sys.stdout, indent=1)'
+echo
+notmuch show --format=json --entire-thread=false --verify=true id:signed+encrypted+legacy-display@protected-headers.example \
+    | python3 -c 'import json,sys; json.dump(json.load(sys.stdin)[0][0][0]["crypto"], sys.stdout, indent=1)'
+echo
+notmuch dump

--- a/test-notmuch
+++ b/test-notmuch
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# testing the test vector generator with notmuch
+set -e
+
+workdir=$(mktemp -d)
+mkdir -p -m 0700 "$workdir/"{g,m/{new,cur,tmp}}
+cleanup() {
+    rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+export GNUPGHOME="$workdir/g"
+export NOTMUCH_CONFIG="$workdir/nm-config"
+cat >"$NOTMUCH_CONFIG" <<EOF
+[new]
+[database]
+path=$workdir/m
+[user]
+name=Bob Babbage
+primary_email=bob@openpgp.example
+[new]
+tags=unread;inbox;
+ignore=
+[maildir]
+synchronize_flags=true
+[search]
+exclude_tags=deleted;spam;
+EOF
+# from https://tools.ietf.org/html/draft-bre-openpgp-samples-00#section-2.1:
+gpg --batch --quiet --no-tty --import <<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Alice's OpenPGP certificate
+
+mDMEXEcE6RYJKwYBBAHaRw8BAQdArjWwk3FAqyiFbFBKT4TzXcVBqPTB3gmzlC/U
+b7O1u120JkFsaWNlIExvdmVsYWNlIDxhbGljZUBvcGVucGdwLmV4YW1wbGU+iJAE
+ExYIADgCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQTrhbtfozp14V6UTmPy
+MVUMT0fjjgUCXaWfOgAKCRDyMVUMT0fjjukrAPoDnHBSogOmsHOsd9qGsiZpgRnO
+dypvbm+QtXZqth9rvwD9HcDC0tC+PHAsO7OTh1S1TC9RiJsvawAfCPaQZoed8gK4
+OARcRwTpEgorBgEEAZdVAQUBAQdAQv8GIa2rSTzgqbXCpDDYMiKRVitCsy203x3s
+E9+eviIDAQgHiHgEGBYIACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjgUCXEcE6QIb
+DAAKCRDyMVUMT0fjjlnQAQDFHUs6TIcxrNTtEZFjUFm1M0PJ1Dng/cDW4xN80fsn
+0QEA22Kr7VkCjeAEC08VSTeV+QFsmz55/lntWkwYWhmvOgE=
+=iIGO
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+gpg --quiet --batch --no-tty --pinentry-mode=loopback --passphrase '' --quick-gen-key 'Local Test Suite Trust Anchor' futuredefault
+gpg --quiet --batch --no-tty --yes --lsign alice@openpgp.example
+notmuch new --quiet
+./generate-test-vectors.py sign | notmuch insert
+notmuch show --format=json --entire-thread=false --verify=true id:signed-only@protected-headers.example \
+    | python3 -c 'import json,sys; json.dump(json.load(sys.stdin)[0][0][0]["crypto"], sys.stdout, indent=1)'


### PR DESCRIPTION
This branch starts the creation of a series of test vectors that show well-structured Protected Headers.

The idea is to include some python3 that permits generation of the example vectors, and then to include those vectors in the draft itself.

Thus far it only includes a single testing example: a signed-only message.

I think we want at least two other well-formed examples:

 - a signed+encrypted message with an Obscured Subject
 - a signed+encrypted message with an Obscured Subject and Legacy Display

But for now i'm hoping to get feedback about whether this seems OK for the moment.