### PR TITLE
Add more test vectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,14 @@
 
 draft = draft-protected-headers
 OUTPUT = $(draft).txt $(draft).html $(draft).xml
+vectors = $(shell ./generate-test-vectors list-vectors)
+vectordata = $(foreach x,$(vectors), $(x).eml)
 
 all: $(OUTPUT)
 
 %.xml: %.md
-	kramdown-rfc2629 < $< > $@
+	kramdown-rfc2629 < $< > $@.tmp
+	mv $@.tmp $@
 
 %.html: %.xml
 	xml2rfc $< --html --v3
@@ -14,7 +17,16 @@ all: $(OUTPUT)
 %.txt: %.xml
 	xml2rfc $< --text --v3
 
+$(draft).md: $(draft).in.md assemble $(vectordata)
+	./assemble < $< >$@.tmp
+	mv $@.tmp $@
+
+%.eml: generate-test-vectors
+	./generate-test-vectors $* >$@.tmp
+	mv $@.tmp $@
+
 clean:
-	-rm -rf $(OUTPUT) .refcache/ metadata.min.js
+	-rm -rf $(OUTPUT) .refcache/ metadata.min.js *.tmp
 
 .PHONY: clean all
+.SECONDARY: $(vectordata) draft-protected-headers.md

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(draft).md: $(draft).in.md assemble $(vectordata)
 	mv $@.tmp $@
 
 clean:
-	-rm -rf $(OUTPUT) .refcache/ metadata.min.js *.tmp
+	-rm -rf $(OUTPUT) metadata.min.js *.tmp
 
 .PHONY: clean all
 .SECONDARY: $(vectordata) draft-protected-headers.md

--- a/assemble
+++ b/assemble
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import re
+import sys
+
+from typing import Pattern
+
+splicer:Pattern = re.compile('^@@(.*)@@$', re.M)
+
+indata:str = sys.stdin.read()
+for data in splicer.findall(indata):
+    with open(data, 'r') as fromfile:
+        indata = indata.replace(f'\n@@{data}@@\n', f'\n{fromfile.read().strip()}\n')
+
+sys.stdout.write(indata)

--- a/draft-protected-headers.in.md
+++ b/draft-protected-headers.in.md
@@ -797,46 +797,7 @@ Note that if this message had been generated without Protected Headers, then an 
 Such an attacker could cause Bob to think that Alice wanted to cancel the contract with BarCorp instead of FooCorp.
 
 ~~~
-Received: from localhost (localhost [127.0.0.1]);
- Sun, 20 Oct 2019 09:18:28 -0400 (UTC-04:00)
-MIME-Version: 1.0
-Content-Type: multipart/signed; boundary="904b809781";
- protocol="application/pgp-signature"; micalg="pgp-sha512"
-From: Alice Lovelace <alice@openpgp.example>
-To: Bob Babbage <bob@openpgp.example>
-Date: Sun, 20 Oct 2019 09:18:11 -0400
-Subject: The FooCorp contract
-Message-ID: <signed-only@protected-headers.example>
-
---904b809781
-Content-Type: text/plain; charset="us-ascii"
-From: Alice Lovelace <alice@openpgp.example>
-To: Bob Babbage <bob@openpgp.example>
-Date: Sun, 20 Oct 2019 09:18:11 -0400
-Subject: The FooCorp contract
-Message-ID: <signed-only@protected-headers.example>
-
-Bob, we need to cancel this contract.
-
-Please start the necessary processes to make that happen today.
-
-Thanks, Alice
--- 
-Alice Lovelace
-President
-OpenPGP Example Corp
-
---904b809781
-Content-Type: application/pgp-signature; charset="us-ascii"
-
------BEGIN PGP SIGNATURE-----
-
-wl4EARYKAAYFAl2sXpMACgkQ8jFVDE9H444uYwD/TpkvOT+KNMAzk00kkFM0/W/n
-noY9JG+8I1rxMH5CpskA+wXacRQ/xoDjwEBL671CDDXYTi/QiOK5vA64gUxDbE0L
-=1tUZ
------END PGP SIGNATURE-----
-
---904b809781--
+@@signed.eml@@
 ~~~
 
 Signed and Encrypted Message with Protected Headers {#encryptedsigned}
@@ -864,55 +825,7 @@ The session key for this message's crypto layer is an AES-256 key with value `8d
 If Bob's MUA is capable of interpreting these protected headers, it should render the `Subject:` of this message as `BarCorp contract signed, let's go!`.
 
 ~~~
-Received: from localhost (localhost [127.0.0.1]);
- Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
-MIME-Version: 1.0
-Content-Type: multipart/encrypted; boundary="bcde3ce988";
- protocol="application/pgp-encrypted"
-From: Alice Lovelace <alice@openpgp.example>
-To: Bob Babbage <bob@openpgp.example>
-Date: Mon, 21 Oct 2019 07:18:11 -0700
-Message-ID: <signed+encrypted@protected-headers.example>
-Subject: ...
-
---bcde3ce988
-Content-Type: application/pgp-encrypted; charset="us-ascii"
-
-Version: 1
-
---bcde3ce988
-Content-Type: application/octet-stream; charset="us-ascii"
-
------BEGIN PGP MESSAGE-----
-
-wV4DR2b2udXyHrYSAQdA8sJB4yKldNgJl9n0ETWERq8xapTZNCECEIdT8rU62Wgw
-zxU9dwhuamBCF81fXDf/qlLd+gi6xYxhqNpnEJU48vaoq8iyUymU1eKowQ/pnKA5
-wcDMA3wvqk35PDeyAQv/a7KZ3aMmf4tqk4VlKPd6l5+JTx8Mb2cu7E++xXqAjMdr
-vAOzpvAj4qzPwWyVe+ygIqcJYg0EAMiPkD/zMhWtn3rAh3/iAHRKcMIMblS4EEnR
-ykG04jfQ73bpX4J/YLTFBNnUMF/+t3tt2xJzo5YX5jUby01J9qMz8GA2SWuNSiN/
-LWtPXp13ShqHwX5DDtE+M7Od2ApEzSBo6Uj2lqIdCs+i4u/35HRPGIrTefED5ecB
-eL4ybuZdxwta+F0QFBQ0HO8R8uio1u7xCyx/KTRejpllG8FVRkiRD3QRf0N+7d7U
-T/etRm0VhR2zYhQPEfGVr8hQ/ZSWme5QEsFkMZRJIB+/KDXn/8wdcE/Jqs+yj+hr
-XwAoxGuiN6JagrQDe9RWEZt4cmAwSQzDY8ai/4WLd8sJOssx5LwUEW92ZclLd82X
-CLR1RoOLNOxfArwoPiTJiXxgUfIZjmOAlamIGUPtZCFkYeItYFnCiDaalfCwrJX8
-j4kzAX3p/qPEdK4QWBxS0sHHASVlm4xktQ1Z2IzB7GX2h3oVK8NdzrUZEYc80+ed
-pL8mEGerujQHTtCNFPU9A2NqcriLwYg9kMDMtyk/o8tL3LHIXolOod7kVGCCAWJ8
-tPRggmVi5Ly0tPNRDU5HJDHz0kINhd3InBvUZpoiNTZrtAnmIhKgE/Fn/4bGrY0H
-UGoAGyVbs5SifNmqP9GNXEqov+h4MchzWs5hn2Vj5jnjc8+cXXJhHU/b84QHPLmN
-vLFZLq71+3gC8XM1QktYctPhI4oesD9kuCCaEbKZbqs6Cagyl8lSslMB0VyNiAVp
-niJ2AL1+bHOUjO1SFn8EQyKjKHD1Wsbc7wwuSRi1ukzTaO3g6PHmwyhoxE/RZp0D
-OZkV3rdKEtPjh0d57SW6cIPm72UX6c2HjWKHEakX9dLTc3OS8vDtBRfUGOwcrlcN
-w/Q4qte1daqUTEpcldEY03pe+VbWtprCuM192clHqvTY0UNFfaEP+ZiJrj9toaGZ
-lqo6eZS/DOdywgOFuZkfsLcAYk/PhBLTle9t5R7jMd4PflX59uGQCytQsiat/nJl
-KAd7zF8cXrxEzAISt/WKlsbGaZo371BQc2JuAr3zFUdR9HWu1knlJsUFgm4x65RK
-pqryozyQy2zUt61lisMvm6qmo6TWzrDqCK1PDHaNRO2WRFOGxAAGc1Ypa/UPCXrL
-jfpU13eh1fiNwmhWlT3/0IH0JXY5wSjCXiHTBRjMr/5pN70wXX14xDOirOoj45ef
-j2eVi38yIkT6m/vrYJxUoahQZTl0gK+hExIYXftR9BXf50I23vAspwRCE5c+RRnt
-ACZcaqsLro8SNaJdSCrFVxmuqN+h4JO8ppso5wRwPLErVPpIlC5RpDM=
-=CatE
------END PGP MESSAGE-----
-
---bcde3ce988--
+@@signed+encrypted.eml@@
 ~~~
 
 Signed and Encrypted Message with Protected Headers and Legacy Display Part
@@ -939,57 +852,7 @@ But if Bob's MUA is capable of decryption but is unaware of protected headers, i
 For this message, the session key is an AES-256 key with value `95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e` (in hex).
 
 ~~~
-Received: from localhost (localhost [127.0.0.1]);
- Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
-MIME-Version: 1.0
-Content-Type: multipart/encrypted; boundary="73c8655345";
- protocol="application/pgp-encrypted"
-From: Alice Lovelace <alice@openpgp.example>
-To: Bob Babbage <bob@openpgp.example>
-Date: Mon, 21 Oct 2019 07:18:11 -0700
-Message-ID: <signed+encrypted+legacy-display@protected-headers.example>
-Subject: ...
-
---73c8655345
-Content-Type: application/pgp-encrypted; charset="us-ascii"
-
-Version: 1
-
---73c8655345
-Content-Type: application/octet-stream; charset="us-ascii"
-
------BEGIN PGP MESSAGE-----
-
-wV4DR2b2udXyHrYSAQdAHI4CaIxAXy7Iv16FZmMd/p+T+KWEwxDrllVS8jkNCWcw
-HTyfe2pnyOw3NPuwEDXcvLKTl/LC6MonWW1t91MqRnnzpUN3Kdb7gAMrmN5RMstH
-wcDMA3wvqk35PDeyAQv+NwDQfyY5BFZRI99aphwLI1lfKTg8Tx6Y8ajVHD0x4Ton
-hXnBwwMLO5BSn5/cgqFt/mhNVmILNiv4IrK+alwOLkBw6M0+F0iUiu1w1KrB+PdJ
-a8N038mKIAH3SdMTi7ryTyUq2+Hl44AVNWKmFdwesAE7b3cA1g1ZztGE1GV+WD8B
-qGd2IsB09CnkxGgoRb71xjV3ZJ3X7qvWP6B9W7eaM0vLyxA0ap2cJdkv1pGEZhch
-iEtVxmsJrXaQqjf2TJeV4bD8hfdCUpoiE07eFwWN2xBRh0lcN45QXWgpfOBsvLQ9
-Cn6vLb4IQStrhe+oNN90bzNZtAv+odvWLDW0hKP/7TkxncK4MHg/uZO45yLKpdis
-azNgAp8IbLjZ9mPodzZB035OZ+iS6KEEwo/zI/miqX4QtEpuCXIYnTsERoTTNUw7
-EJSZ+RpO0L1jGOQgqlFh+h1zLlvlnphdH72hhPHRcyY4hqQG5gGTWCHl0OA8LMlv
-0s+nYNcbIbJdV4b6s/GL0sIpAcA5Bo/Eu0hC8eXQDJMoQYk3sXhzU5LYu/V5Gn51
-BKPWzTkz+mfvTRkTb/LC8QKifm+kOg/D/IUKT87Ep1yb2on8pj789QkQUSUqO5Hc
-Hp3IElZXSKTUdvpzlQi6UzBRhTV6FqZJtzifQL3HuGPYbv3UwXrQIsA3Cqhm6KL+
-u7BVmXFlhk1Liul59zQs4RfMMHZww8Ios5r7Aib/Trp/Oyyu4erJnLjaip14+amJ
-oDF7L2sln/l9t9YtkkXKwhjsLWnfb/6JL6+MixCrTxGUG/N8TT0O8MvzeLRUiPm0
-GLHcTT9R6kO1+1BDsKpBlzChzSeHkH30lkQ6dPkv/C5D7if5f9r+UcIUuO//SEH8
-XYFjAyhi/HSZONgshmWebZxhN5AVR6qbl84/wowJf9xOpfbiW1Vdg+7gQ3m7RFPh
-/1AoC2NDkOWKo70ctEzDtnbRPUNa9aaptjJYKWKvURDhaQ5yVz/A7Wr/cmks+FMp
-S8HAdBH8+I//5OPVJHgeuO004b8YzADawajm4u7rL7nccaPCFbAZXIoX/78XNqRw
-TJGwE8MPu5w3b8d4fKk++PDHVnvIyofo7n2ST+SAS4/KI+VOlAhXmNdkxhKIEHKk
-HUPB2zeEoGVFecRIdMm5dVLtf9EOBE8QZvQnxiYN05TQ9ECaJ0ONWRjYCC8EiRme
-gzIOpjIlw81JG+m9yGDp0S7iN5UJCCiolLJy2rPIBxWpJSwALRHy2u46VGyHONfX
-VRfKSZuBwu/kkfDHmw/I7aN8JNWiIrYhaPZ3vuGZ1ZWGtxbgvUlD9lZWG6+UM9+k
-6RF3YLZKXGkJzzh9ipKZFgnWgyOSvRQzMtWSj8GSdKAXRQgQUdYg82jCe2IKYQdf
-UGy7MjEvOJTTHKvMkIuBFrQpPWklWAN4XFAf4m2iciHw/f2WxJ/Nj2HET+OxmFMD
-mZ/z90MZ2jBxCO4Rug18yFC5CsHlt6SeaPPw9GtER7J2YAcE7SXb3iXXqw==
-=9CTX
------END PGP MESSAGE-----
-
---73c8655345--
+@@signed+encrypted+legacy-display.eml@@
 ~~~
 
 Multilayer Message with Protected Headers
@@ -1013,58 +876,7 @@ A typical message like this has the following structure:
 For this message, the session key is an AES-256 key with value `5e67165ed1516333daeba32044f88fd75d4a9485a563d14705e41d31fb61a9e9` (in hex).
 
 ~~~
-Received: from localhost (localhost [127.0.0.1]);
- Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
-MIME-Version: 1.0
-Content-Type: multipart/encrypted; boundary="15d01ebd43";
- protocol="application/pgp-encrypted"
-From: Alice Lovelace <alice@openpgp.example>
-To: Bob Babbage <bob@openpgp.example>
-Date: Mon, 21 Oct 2019 07:18:11 -0700
-Message-ID: <multilayer@protected-headers.example>
-Subject: ...
-
---15d01ebd43
-Content-Type: application/pgp-encrypted; charset="us-ascii"
-
-Version: 1
-
---15d01ebd43
-Content-Type: application/octet-stream; charset="us-ascii"
-
------BEGIN PGP MESSAGE-----
-
-wV4DR2b2udXyHrYSAQdALisA4cv7zACDEO+CXztz+3W3MvC+glbQYDPLa6AJABAw
-BXvkGaEdDwvngGjlkLQAFvFGGI7bkA8Th2uZbIUHL9IxKn9WCcBwv9CK8u4Pazs5
-wcDMA3wvqk35PDeyAQwAvUOUw4KT7rKbyaEZhl1QBZ2Y75DuZrCTG49qztiIe/71
-uWRStJn4m1xqVxDNTsmsI463iZO1PUG1vEPNBWOW0aE3STYpju4mBEkjlTwDtlgL
-IpxNjXsNE61rqmaCT7l7PIGWG12Msdp0SIV6LSp2+ajhbZvko6x8/lbtZir0vCDH
-hHSgTkMYpNREtUy8rMSMFDK2xNJhfJz5Ohc4Pg+5Fhyb51OGpvUvtt8EreaTJTl4
-V9jFAvCBoaZKifcKsoXFkhsYJJ4nLjEMXuyxQsSmNX6SsnUlNxVtdGHaVih0YkUh
-d9vYWpikxAOP3fa12Kgg0iJayGOWHCsmqoEvD8QIjakFT0nPDaI63oueSHwuZ6Xl
-UhM4WksqFJtue9lPcVdXkTgJzo9lbDalxsVC3ZWBM/xNHrOWV2Qe1BjGWx/y/mjv
-sccB5kSgeJ8v/Im3N5if70URSmf8e2j9/guAKPuQsWcBQ3OMOJdY/Z0Slj16wn93
-jl4HikjTZOHk9qoc5BvT0sIwAXluUxOKPucKhBdngIX379FYLFdq/bEFI9nJyYQ4
-au14k8n6VCw3I6ZEaKdsRGeIns1oZhFG89oHkP8HrVxnAoQShSbprJi3H4G96ndW
-7xHUDDVTZrvODE9trDrTZ1uO3o1IL4L/epEdqgKrOIHHjpazf4HpahkZVO5Id6RB
-Z1sOBKEhYQK57nvUNNNtwaX0gmF54u2BIVrEu/rVMl/l9lxdB/RoqJlcKwEQ9gjY
-M2kORuYVQYiC9D1NkIr3yxHLPmJ182LQEbpH+yJuCy+CjlFt9nwogqwua0tnHv9k
-RGOz1XAcBDj74Jq/DeF8a1JyI7kJ5mV8GLrkUHhKT8rjpvEBrdIpnadGLdVgLHJn
-8lUBrm9bnWK4Dum1XeYUQnhOW27UgjA7jkKlfNlieqf5g/ITxBMxghuR99nEu0D2
-cUcVeV5L1bTN+rePtn7oI+N58GvaMQgoarlhoUjyc2vkknmrt8qzP26C8eQqyFG7
-sWz0XvTjPmPspXw2aXSgTHRzOWlLOY0tVWOcnZjX/F7HFfyNOkduDViJQDdAFrKF
-FL2gbiRGlvq0Bdc2r/Gq8gd4P/bCdyZgOr05+QDSmSmFJqJ1bi4YVsqKu1bzlv7P
-MCBjv6BRvsBKoGaoHU3EjSAUtBYIhtT5dVQ3p/fq0GFaOXtbK7FMz/Eb63HRnx0u
-vFnNenmMGaAnxKg9kLEyzby/xa4hOYSHTz87Fn5QgoV6Rl3/tOMCQFQQ69fwRruO
-m6l2gaTfuHgW/G3Wdn7jPEFNxVzp+huJW0tU1LLXCvFI4zSXV/pzSbe4md8J81sf
-3DHDvZBGNWGHdTkrH3YKwc6k+aX5jnczwJk1HVakyuxHwEQOBBVvUov0LjpaipzL
-6DB5gBC90vB+FWT9NM5/6QE3KiSdW/ihS+PkuhlaASNKba9JW5lH15FiYOiM1b0E
-VFuMF2xHmekkF4qBlt6puMfWz6quNm3OvcFrsDbElERUraWUtYGwkfUupQj7H/ov
-tYY=
-=uRGE
------END PGP MESSAGE-----
-
---15d01ebd43--
+@@multilayer.eml@@
 ~~~
 
 Multilayer Message with Protected Headers and Legacy Display Part
@@ -1089,59 +901,7 @@ Such a message might have the following structure:
 For this message, the session key is an AES-256 key with value `b346a2a50fa0cf62895b74e8c0d2ad9e3ee1f02b5d564c77d879caaee7a0aa70` (in hex).
 
 ~~~
-Received: from localhost (localhost [127.0.0.1]);
- Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
-MIME-Version: 1.0
-Content-Type: multipart/encrypted; boundary="750bb87f7c";
- protocol="application/pgp-encrypted"
-From: Alice Lovelace <alice@openpgp.example>
-To: Bob Babbage <bob@openpgp.example>
-Date: Mon, 21 Oct 2019 07:18:11 -0700
-Message-ID: <multilayer+legacy-display@protected-headers.example>
-Subject: ...
-
---750bb87f7c
-Content-Type: application/pgp-encrypted; charset="us-ascii"
-
-Version: 1
-
---750bb87f7c
-Content-Type: application/octet-stream; charset="us-ascii"
-
------BEGIN PGP MESSAGE-----
-
-wV4DR2b2udXyHrYSAQdA6mQ/9D8CSyobcD8emWZgbFvKnQP60EpqIuxYRqoTp04w
-G6tFVuLkIYT7UoQKC69zamczDk31nAMuRbakY/UvRKr4Omlt9ftyfHKyZ4dTY/2x
-wcDMA3wvqk35PDeyAQwAspo+fPgNVGMSf6zRrbLqsJO6WK0j/UrKwosnz41J5YcX
-arIV5Wk2Cg7RD7XFVXt7slQCjfCX14WYlRCBJN1+c7sdMoz2+s2v095k1eR06tKm
-Zhm+mkfJ11np66cZ+YlNGf95lTg7u70j/fbDstr00UbWYKwHIdSG16gZOOuq0JQR
-sXBmSouhwl2iEOFGl/Y3qKMCnZUiOQHwC+Gaicvt1ux51nvxiJI2M9979JsLS83p
-z5qd8iRQRW8Er2pMzz7ih8L/DaQYBp2AYvHQGjI0KE35rRNhAzWNkmOYV3TJD8ZK
-KVu2xrNttZbQvC2Stpw7hxn6xbM97PecPxkOrkMnn53j0wojM5xCKNCEvLXwWnlY
-usoF7bRnWc4QIxDjuurjhp8F2+AhX7HP6lu98WzU4TLgSFIVruxf7LxgcqYR2Yjx
-Ecql1ZFNodo6gBS07K3dEmJvzKGQkFqm0PAwMPufN6l9IgTol4NRSkrT4OzQCS76
-0osrny2lterb0Ibbi5g40sKNAfeqxCcMihOacKaymVnHQRpA9Egx2bKByFyf1WgC
-5PG5OsBU+wsLm8U5fu4bKag29sA1bv+6yYl86aX4AXw9JGUD5k3mfbucWC5CXNhX
-wlbjkMHq1vJHYLnYRhM8qxy/l/XkFcCGMO2Ueg0mK+HaKQmneObZlq+iX5wQr58J
-OPRXRlT8ZQtowvXqiR9743t8zS7GSNH2DHiwHA2HU/1j8s2KGlsTYLihWhADKeYJ
-cf6LKjH0TKiCVIjU3mNpMIW6Sg7UXpeYAQv6eNgJhCbGrlzgFxavYz2hmthoV5x5
-8bpVFo9BM+tMdSGKZHNocotATce5eMJtGbxG80//JcpdlcTuNe1PP83fezrLrHKH
-weHKGQFWF9RUn7KixPTkvH0/ucz7v0OoAocWArTpaI7AanjUIbbsB6rAHfuWuIex
-4Nck0Z4h7WJyLOH34rL+z7EPg8QEKWPiBbZeMjn52aPiWoZ5BM6yf+n9ZBcRelp/
-MgXbLqmpxAiJmCPYwlamhfxus8yJ4zAt9D9ma0AA1FGrUnRuLfZKFMj7vd6TFs5R
-7k8QGvf82GlMLHllQm9UErSWrZ2QtmvcmfORZubqctJwAz3+HPHPbZEyOwQDFvw2
-Q1XQUuK1wi1Xb2EeopDAgw3MY+rsOZJfH25fivFk8L5l4FJc1vIiBf7c/FZXrOVp
-xer0g062O79KqfHUlW4JaZLSbgSmaD9Je6l/eEUAqbssX7U9kNRnumNdrMI2NJxw
-2sPwAwYVweUtnG3Wej0gqsbHyV1fCqtWPZql0ifkn1xcnpRusTXAab9p9cn8/dwE
-y8soEECJPAmI57DLl/wsyOchIQ7aUlSmlGadmdZYX2u9/LmP+fwb9u+Noc8Zpca+
-rAD5qGiak7XYybdaOhUNAZTuQle9pnJ8MZPIrKqgjeNBgWjsvNwN/5VTQ+AFUejt
-tv0UmhZVWwn6+D1yKnemyT3ndVVTCrtRnE3WUn0OZp/ANMwj0wniC/kioVt9b9Q6
-n7w06BFe20zZq4V136GIHNr2n1BmpiSw0tZJe2J/URMynI33oAbfyxW3BBt2HdoT
-5jPAQLUx8T3gCUnrWQTDI1UR2LGKhyOB3MMZPYIqbhuFBpXI43jptjMS3pN8D/4=
-=Lhn3
------END PGP MESSAGE-----
-
---750bb87f7c--
+@@multilayer+legacy-display.eml@@
 ~~~
 
 

--- a/draft-protected-headers.in.md
+++ b/draft-protected-headers.in.md
@@ -904,6 +904,40 @@ For this message, the session key is an AES-256 key with value `b346a2a50fa0cf62
 @@multilayer+legacy-display.eml@@
 ~~~
 
+An Unfortunately Complex Example
+--------------------------------
+
+For all of the potential complexity of the Cryptographic Envelope, the Cryptographic Payload itself can be complex.
+The Cryptographic Envelope in this example is the same as the previous example (multilayer signed encrypted).
+The Cryptographic Payload has protected headers and a legacy display part (also the same as the previous example), but in addition Alice's MUA composes a message with both plaintext and HTML variants, and Alice includes a single attachment as well.
+
+While this message is complex, a modern MUA could also plausibly generate such a structure based on reasonable commands from the user composing the message (e.g., Alice composes the message with a rich text editor, and attaches a file to the message).
+
+The key takeaway is that the complexity of the Cryptographic Payload (which may contain a Legacy Display part) is independent of and distinct from the complexity of the Cryptographic Envelope.
+
+This message has the following structure:
+
+~~~
+└┬╴multipart/encrypted
+ ├─╴application/pgp-encrypted
+ └─╴application/octet-stream
+  ↧ (decrypts to)
+  └┬╴multipart/signed
+   ├┬╴multipart/mixed
+   │├─╴text/rfc822-headers
+   │└┬╴multipart/mixed
+   │ ├┬╴multipart/alternative
+   │ │├─╴text/plain
+   │ │└─╴text/html
+   │ └─╴text/x-diff
+   └─╴application/pgp-signature
+~~~
+
+For this message, the session key is an AES-256 key with value `1c489cfad9f3c0bf3214bf34e6da42b7f64005e59726baa1b17ffdefe6ecbb52` (in hex).
+
+~~~
+@@unfortunately-complex.eml@@
+~~~
 
 IANA Considerations
 ===================

--- a/draft-protected-headers.in.md
+++ b/draft-protected-headers.in.md
@@ -789,9 +789,11 @@ Signed Message with Protected Headers {#test-vector-signed-only}
 
 This shows a clearsigned message.  Its MIME message structure is:
 
-    └┬╴multipart/signed
-     ├─╴text/plain
-     └─╴application/pgp-signature
+~~~
+└┬╴multipart/signed
+ ├─╴text/plain
+ └─╴application/pgp-signature
+~~~
 
 Note that if this message had been generated without Protected Headers, then an attacker with access to it could modify the Subject without invalidating the signature.
 Such an attacker could cause Bob to think that Alice wanted to cancel the contract with BarCorp instead of FooCorp.
@@ -807,11 +809,13 @@ This shows a simple encrypted message with protected headers.
 The encryption also contains an signature in the OpenPGP Message structure.
 Its MIME message structure is:
 
-    └┬╴multipart/encrypted
-     ├─╴application/pgp-encrypted
-     └─╴application/octet-stream
-       ↧ (decrypts to)
-       └─╴text/plain
+~~~
+└┬╴multipart/encrypted
+ ├─╴application/pgp-encrypted
+ └─╴application/octet-stream
+   ↧ (decrypts to)
+   └─╴text/plain
+~~~
 
 The `Subject:` header is successfully obscured.
 
@@ -835,13 +839,15 @@ If Alice's MUA wasn't sure whether Bob's MUA would know to render the obscured `
 
 This message is structured in the following way:
 
-    └┬╴multipart/encrypted
-     ├─╴application/pgp-encrypted
-     └─╴application/octet-stream
-       ↧ (decrypts to)
-       └┬╴multipart/mixed
-        ├─╴text/rfc822-headers
-        └─╴text/plain
+~~~
+└┬╴multipart/encrypted
+ ├─╴application/pgp-encrypted
+ └─╴application/octet-stream
+   ↧ (decrypts to)
+   └┬╴multipart/mixed
+    ├─╴text/rfc822-headers
+    └─╴text/plain
+~~~
 
 The example below shows the same message as {{encryptedsigned}}.
 

--- a/draft-protected-headers.in.md
+++ b/draft-protected-headers.in.md
@@ -791,7 +791,7 @@ This shows a clearsigned message.  Its MIME message structure is:
 
 ~~~
 └┬╴multipart/signed
- ├─╴text/plain
+ ├─╴text/plain ← Cryptographic Payload
  └─╴application/pgp-signature
 ~~~
 
@@ -814,7 +814,7 @@ Its MIME message structure is:
  ├─╴application/pgp-encrypted
  └─╴application/octet-stream
    ↧ (decrypts to)
-   └─╴text/plain
+   └─╴text/plain ← Cryptographic Payload
 ~~~
 
 The `Subject:` header is successfully obscured.
@@ -844,8 +844,8 @@ This message is structured in the following way:
  ├─╴application/pgp-encrypted
  └─╴application/octet-stream
    ↧ (decrypts to)
-   └┬╴multipart/mixed
-    ├─╴text/rfc822-headers
+   └┬╴multipart/mixed ← Cryptographic Payload
+    ├─╴text/rfc822-headers ← Legacy Display Part
     └─╴text/plain
 ~~~
 
@@ -875,7 +875,7 @@ A typical message like this has the following structure:
  └─╴application/octet-stream
   ↧ (decrypts to)
   └┬╴multipart/signed
-   ├─╴text/plain
+   ├─╴text/plain ← Cryptographic Payload
    └─╴application/pgp-signature
 ~~~
 
@@ -898,8 +898,8 @@ Such a message might have the following structure:
  └─╴application/octet-stream
   ↧ (decrypts to)
   └┬╴multipart/signed
-   ├┬╴multipart/mixed
-   │├─╴text/rfc822-headers
+   ├┬╴multipart/mixed ← Cryptographic Payload
+   │├─╴text/rfc822-headers ← Legacy Display Part
    │└─╴text/plain
    └─╴application/pgp-signature
 ~~~
@@ -929,13 +929,13 @@ This message has the following structure:
  └─╴application/octet-stream
   ↧ (decrypts to)
   └┬╴multipart/signed
-   ├┬╴multipart/mixed
-   │├─╴text/rfc822-headers
+   ├┬╴multipart/mixed ← Cryptographic Payload
+   │├─╴text/rfc822-headers ← Legacy Display Part
    │└┬╴multipart/mixed
    │ ├┬╴multipart/alternative
    │ │├─╴text/plain
    │ │└─╴text/html
-   │ └─╴text/x-diff
+   │ └─╴text/x-diff ← attachment
    └─╴application/pgp-signature
 ~~~
 

--- a/draft-protected-headers.md
+++ b/draft-protected-headers.md
@@ -992,6 +992,159 @@ mZ/z90MZ2jBxCO4Rug18yFC5CsHlt6SeaPPw9GtER7J2YAcE7SXb3iXXqw==
 --73c8655345--
 ~~~
 
+Multilayer Message with Protected Headers
+-----------------------------------------
+
+Some mailers may generate signed and encrypted messages with a multilayer cryptographic envelope.
+We show here how such a mailer might generate the same message from Alice to Bob.
+
+A typical message like this has the following structure:
+
+~~~
+└┬╴multipart/encrypted
+ ├─╴application/pgp-encrypted
+ └─╴application/octet-stream
+  ↧ (decrypts to)
+  └┬╴multipart/signed
+   ├─╴text/plain
+   └─╴application/pgp-signature
+~~~
+
+For this message, the session key is an AES-256 key with value `5e67165ed1516333daeba32044f88fd75d4a9485a563d14705e41d31fb61a9e9` (in hex).
+
+~~~
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="15d01ebd43";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <multilayer@protected-headers.example>
+Subject: ...
+
+--15d01ebd43
+Content-Type: application/pgp-encrypted; charset="us-ascii"
+
+Version: 1
+
+--15d01ebd43
+Content-Type: application/octet-stream; charset="us-ascii"
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdALisA4cv7zACDEO+CXztz+3W3MvC+glbQYDPLa6AJABAw
+BXvkGaEdDwvngGjlkLQAFvFGGI7bkA8Th2uZbIUHL9IxKn9WCcBwv9CK8u4Pazs5
+wcDMA3wvqk35PDeyAQwAvUOUw4KT7rKbyaEZhl1QBZ2Y75DuZrCTG49qztiIe/71
+uWRStJn4m1xqVxDNTsmsI463iZO1PUG1vEPNBWOW0aE3STYpju4mBEkjlTwDtlgL
+IpxNjXsNE61rqmaCT7l7PIGWG12Msdp0SIV6LSp2+ajhbZvko6x8/lbtZir0vCDH
+hHSgTkMYpNREtUy8rMSMFDK2xNJhfJz5Ohc4Pg+5Fhyb51OGpvUvtt8EreaTJTl4
+V9jFAvCBoaZKifcKsoXFkhsYJJ4nLjEMXuyxQsSmNX6SsnUlNxVtdGHaVih0YkUh
+d9vYWpikxAOP3fa12Kgg0iJayGOWHCsmqoEvD8QIjakFT0nPDaI63oueSHwuZ6Xl
+UhM4WksqFJtue9lPcVdXkTgJzo9lbDalxsVC3ZWBM/xNHrOWV2Qe1BjGWx/y/mjv
+sccB5kSgeJ8v/Im3N5if70URSmf8e2j9/guAKPuQsWcBQ3OMOJdY/Z0Slj16wn93
+jl4HikjTZOHk9qoc5BvT0sIwAXluUxOKPucKhBdngIX379FYLFdq/bEFI9nJyYQ4
+au14k8n6VCw3I6ZEaKdsRGeIns1oZhFG89oHkP8HrVxnAoQShSbprJi3H4G96ndW
+7xHUDDVTZrvODE9trDrTZ1uO3o1IL4L/epEdqgKrOIHHjpazf4HpahkZVO5Id6RB
+Z1sOBKEhYQK57nvUNNNtwaX0gmF54u2BIVrEu/rVMl/l9lxdB/RoqJlcKwEQ9gjY
+M2kORuYVQYiC9D1NkIr3yxHLPmJ182LQEbpH+yJuCy+CjlFt9nwogqwua0tnHv9k
+RGOz1XAcBDj74Jq/DeF8a1JyI7kJ5mV8GLrkUHhKT8rjpvEBrdIpnadGLdVgLHJn
+8lUBrm9bnWK4Dum1XeYUQnhOW27UgjA7jkKlfNlieqf5g/ITxBMxghuR99nEu0D2
+cUcVeV5L1bTN+rePtn7oI+N58GvaMQgoarlhoUjyc2vkknmrt8qzP26C8eQqyFG7
+sWz0XvTjPmPspXw2aXSgTHRzOWlLOY0tVWOcnZjX/F7HFfyNOkduDViJQDdAFrKF
+FL2gbiRGlvq0Bdc2r/Gq8gd4P/bCdyZgOr05+QDSmSmFJqJ1bi4YVsqKu1bzlv7P
+MCBjv6BRvsBKoGaoHU3EjSAUtBYIhtT5dVQ3p/fq0GFaOXtbK7FMz/Eb63HRnx0u
+vFnNenmMGaAnxKg9kLEyzby/xa4hOYSHTz87Fn5QgoV6Rl3/tOMCQFQQ69fwRruO
+m6l2gaTfuHgW/G3Wdn7jPEFNxVzp+huJW0tU1LLXCvFI4zSXV/pzSbe4md8J81sf
+3DHDvZBGNWGHdTkrH3YKwc6k+aX5jnczwJk1HVakyuxHwEQOBBVvUov0LjpaipzL
+6DB5gBC90vB+FWT9NM5/6QE3KiSdW/ihS+PkuhlaASNKba9JW5lH15FiYOiM1b0E
+VFuMF2xHmekkF4qBlt6puMfWz6quNm3OvcFrsDbElERUraWUtYGwkfUupQj7H/ov
+tYY=
+=uRGE
+-----END PGP MESSAGE-----
+
+--15d01ebd43--
+~~~
+
+Multilayer Message with Protected Headers and Legacy Display Part
+-----------------------------------------------------------------
+
+And, a mailer that generates a multilayer cryptographic envelope might want to provide a Legacy Display part, if it is unsure of the capabilities of the recipient's MUA.
+
+Such a message might have the following structure:
+
+~~~
+└┬╴multipart/encrypted
+ ├─╴application/pgp-encrypted
+ └─╴application/octet-stream
+  ↧ (decrypts to)
+  └┬╴multipart/signed
+   ├┬╴multipart/mixed
+   │├─╴text/rfc822-headers
+   │└─╴text/plain
+   └─╴application/pgp-signature
+~~~
+
+For this message, the session key is an AES-256 key with value `b346a2a50fa0cf62895b74e8c0d2ad9e3ee1f02b5d564c77d879caaee7a0aa70` (in hex).
+
+~~~
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="750bb87f7c";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <multilayer+legacy-display@protected-headers.example>
+Subject: ...
+
+--750bb87f7c
+Content-Type: application/pgp-encrypted; charset="us-ascii"
+
+Version: 1
+
+--750bb87f7c
+Content-Type: application/octet-stream; charset="us-ascii"
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdA6mQ/9D8CSyobcD8emWZgbFvKnQP60EpqIuxYRqoTp04w
+G6tFVuLkIYT7UoQKC69zamczDk31nAMuRbakY/UvRKr4Omlt9ftyfHKyZ4dTY/2x
+wcDMA3wvqk35PDeyAQwAspo+fPgNVGMSf6zRrbLqsJO6WK0j/UrKwosnz41J5YcX
+arIV5Wk2Cg7RD7XFVXt7slQCjfCX14WYlRCBJN1+c7sdMoz2+s2v095k1eR06tKm
+Zhm+mkfJ11np66cZ+YlNGf95lTg7u70j/fbDstr00UbWYKwHIdSG16gZOOuq0JQR
+sXBmSouhwl2iEOFGl/Y3qKMCnZUiOQHwC+Gaicvt1ux51nvxiJI2M9979JsLS83p
+z5qd8iRQRW8Er2pMzz7ih8L/DaQYBp2AYvHQGjI0KE35rRNhAzWNkmOYV3TJD8ZK
+KVu2xrNttZbQvC2Stpw7hxn6xbM97PecPxkOrkMnn53j0wojM5xCKNCEvLXwWnlY
+usoF7bRnWc4QIxDjuurjhp8F2+AhX7HP6lu98WzU4TLgSFIVruxf7LxgcqYR2Yjx
+Ecql1ZFNodo6gBS07K3dEmJvzKGQkFqm0PAwMPufN6l9IgTol4NRSkrT4OzQCS76
+0osrny2lterb0Ibbi5g40sKNAfeqxCcMihOacKaymVnHQRpA9Egx2bKByFyf1WgC
+5PG5OsBU+wsLm8U5fu4bKag29sA1bv+6yYl86aX4AXw9JGUD5k3mfbucWC5CXNhX
+wlbjkMHq1vJHYLnYRhM8qxy/l/XkFcCGMO2Ueg0mK+HaKQmneObZlq+iX5wQr58J
+OPRXRlT8ZQtowvXqiR9743t8zS7GSNH2DHiwHA2HU/1j8s2KGlsTYLihWhADKeYJ
+cf6LKjH0TKiCVIjU3mNpMIW6Sg7UXpeYAQv6eNgJhCbGrlzgFxavYz2hmthoV5x5
+8bpVFo9BM+tMdSGKZHNocotATce5eMJtGbxG80//JcpdlcTuNe1PP83fezrLrHKH
+weHKGQFWF9RUn7KixPTkvH0/ucz7v0OoAocWArTpaI7AanjUIbbsB6rAHfuWuIex
+4Nck0Z4h7WJyLOH34rL+z7EPg8QEKWPiBbZeMjn52aPiWoZ5BM6yf+n9ZBcRelp/
+MgXbLqmpxAiJmCPYwlamhfxus8yJ4zAt9D9ma0AA1FGrUnRuLfZKFMj7vd6TFs5R
+7k8QGvf82GlMLHllQm9UErSWrZ2QtmvcmfORZubqctJwAz3+HPHPbZEyOwQDFvw2
+Q1XQUuK1wi1Xb2EeopDAgw3MY+rsOZJfH25fivFk8L5l4FJc1vIiBf7c/FZXrOVp
+xer0g062O79KqfHUlW4JaZLSbgSmaD9Je6l/eEUAqbssX7U9kNRnumNdrMI2NJxw
+2sPwAwYVweUtnG3Wej0gqsbHyV1fCqtWPZql0ifkn1xcnpRusTXAab9p9cn8/dwE
+y8soEECJPAmI57DLl/wsyOchIQ7aUlSmlGadmdZYX2u9/LmP+fwb9u+Noc8Zpca+
+rAD5qGiak7XYybdaOhUNAZTuQle9pnJ8MZPIrKqgjeNBgWjsvNwN/5VTQ+AFUejt
+tv0UmhZVWwn6+D1yKnemyT3ndVVTCrtRnE3WUn0OZp/ANMwj0wniC/kioVt9b9Q6
+n7w06BFe20zZq4V136GIHNr2n1BmpiSw0tZJe2J/URMynI33oAbfyxW3BBt2HdoT
+5jPAQLUx8T3gCUnrWQTDI1UR2LGKhyOB3MMZPYIqbhuFBpXI43jptjMS3pN8D/4=
+=Lhn3
+-----END PGP MESSAGE-----
+
+--750bb87f7c--
+~~~
+
+
 IANA Considerations
 ===================
 

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -18,15 +18,43 @@ import codecs
 
 import pgpy
 
+cfg = {
+    'signed': {
+        'encrypt': False,
+    },
+    'signed+encrypted': {
+        'encrypt': True,
+        'multilayer': False,
+        'legacy': False,
+        'sk': b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2'
+    },
+    'multilayer': {
+        'encrypt': True,
+        'multilayer': True,
+        'legacy': False,
+        'sk': b'5e67165ed1516333daeba32044f88fd75d4a9485a563d14705e41d31fb61a9e9'
+    },
+    'signed+encrypted+legacy-display': {
+        'encrypt': True,
+        'multilayer': False,
+        'legacy': True,
+        'sk': b'95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e'
+    },
+    'multilayer+legacy-display': {
+        'encrypt': True,
+        'multilayer': True,
+        'legacy': True,
+        'sk': b'b346a2a50fa0cf62895b74e8c0d2ad9e3ee1f02b5d564c77d879caaee7a0aa70'
+    },
+}
+
+
 def usage(to=sys.stdout):
+    subcmds = '\n  '.join(list(cfg.keys()))
     print(f'''Usage: {sys.argv[0]} SUBCMD
 where SUBCMD is one of:
   help
-  sign
-  sign+encrypt
-  sign+encrypt+legacy
-  multilayer
-  multilayer+legacy''', file=to)
+  {subcmds}''', file=to)
 
 # We want maxheaderlen=72 here so that the example fits nicely
 # in an Internet Draft.  But it is risky -- i think it could
@@ -204,7 +232,7 @@ OpenPGP Example Corp'''
         raise NotImplementedError("need to get to multipart")
     return payload
 
-def signed_encrypted(legacy=False, multilayer=False, multipart_payload=False):
+def signed_encrypted(msgid:str, params):
     # seconds since the unix epoch
     posixtime = 1571667491
     # America/Los_Angeles during DST:
@@ -218,21 +246,11 @@ def signed_encrypted(legacy=False, multilayer=False, multipart_payload=False):
     rcvdstring = rcvd.strftime('%a, %d %b %Y %T %z (%Z)').strip()
 
     # make the Cryptographic Payload:
-    payload = make_payload(multipart_payload)
+    payload = make_payload(False)
 
     subj = 'BarCorp contract signed, let\'s go!'
 
-    # index by [legacy][multilayer]:
-    cfg = {False: {False: {'sk': b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2',
-                           'msgid': 'signed+encrypted' },
-                   True: {'sk': b'5e67165ed1516333daeba32044f88fd75d4a9485a563d14705e41d31fb61a9e9',
-                          'msgid': 'multilayer'}},
-           True: {False: {'sk': b'95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e',
-                          'msgid': 'signed+encrypted+legacy-display'},
-                  True: {'sk': b'b346a2a50fa0cf62895b74e8c0d2ad9e3ee1f02b5d564c77d879caaee7a0aa70',
-                         'msgid': 'multilayer+legacy-display'}}}
-
-    if legacy:
+    if params['legacy']:
         legacydisplay = email.message.MIMEPart()
         legacydisplay.set_content(f'Subject: {subj}\n')
         legacydisplay.set_type('text/rfc822-headers')
@@ -257,10 +275,10 @@ def signed_encrypted(legacy=False, multilayer=False, multipart_payload=False):
     payload['Date'] = whenstring
     payload['Subject'] = subj
 
-    sessionkey = codecs.decode(cfg[legacy][multilayer]['sk'], 'hex')
-    payload['Message-ID'] = f"<{cfg[legacy][multilayer]['msgid']}@protected-headers.example>"
+    sessionkey = codecs.decode(params['sk'], 'hex')
+    payload['Message-ID'] = f"<{msgid}@protected-headers.example>"
 
-    if multilayer:
+    if params['multilayer']:
         # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
         # in order for the signature creation time to match the message Date header:
         pgpsig = alice_key.sign(pgpy.PGPMessage.new(str(payload), cleartext=True), created=when)
@@ -328,16 +346,13 @@ if __name__ == '__main__':
         exit(1)
     if sys.argv[1] == 'help':
         usage()
-    elif sys.argv[1] == 'sign':
-        print(signed().as_string(maxheaderlen=MAXHEADERLEN))
-    elif sys.argv[1] == 'sign+encrypt':
-        print(signed_encrypted(False, False).as_string(maxheaderlen=MAXHEADERLEN))
-    elif sys.argv[1] == 'sign+encrypt+legacy':
-        print(signed_encrypted(True, False).as_string(maxheaderlen=MAXHEADERLEN))
-    elif sys.argv[1] == 'multilayer':
-        print(signed_encrypted(False, True).as_string(maxheaderlen=MAXHEADERLEN))
-    elif sys.argv[1] == 'multilayer+legacy':
-        print(signed_encrypted(True, True).as_string(maxheaderlen=MAXHEADERLEN))
+    elif sys.argv[1] in cfg:
+        params = cfg[sys.argv[1]]
+        if not params['encrypt']:
+            msg = signed()
+        else:
+            msg = signed_encrypted(sys.argv[1], params)
+        print(msg.as_string(maxheaderlen=MAXHEADERLEN))
     else:
         print(f'Unknown argument "{sys.argv[1]}"', file=sys.stderr)
         usage(to=sys.stderr)

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -26,25 +26,36 @@ cfg = {
         'encrypt': True,
         'multilayer': False,
         'legacy': False,
+        'multipart': False,
         'sk': b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2'
     },
     'multilayer': {
         'encrypt': True,
         'multilayer': True,
         'legacy': False,
+        'multipart': False,
         'sk': b'5e67165ed1516333daeba32044f88fd75d4a9485a563d14705e41d31fb61a9e9'
     },
     'signed+encrypted+legacy-display': {
         'encrypt': True,
         'multilayer': False,
         'legacy': True,
+        'multipart': False,
         'sk': b'95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e'
     },
     'multilayer+legacy-display': {
         'encrypt': True,
         'multilayer': True,
         'legacy': True,
+        'multipart': False,
         'sk': b'b346a2a50fa0cf62895b74e8c0d2ad9e3ee1f02b5d564c77d879caaee7a0aa70'
+    },
+    'unfortunately-complex': {
+        'encrypt': True,
+        'multilayer': True,
+        'legacy': True,
+        'multipart': True,
+        'sk': b'1c489cfad9f3c0bf3214bf34e6da42b7f64005e59726baa1b17ffdefe6ecbb52'
     },
 }
 
@@ -132,7 +143,7 @@ def getsigpart(pgpsig:pgpy.PGPSignature) -> email.message.MIMEPart:
     sigpart = email.message.MIMEPart()
     sigpart.set_content(str(pgpsig).strip())
     sigpart.set_type('application/pgp-signature')
-    sigpart.set_charset('us-ascii') # the test vector data is 7-bit clean
+    sigpart.set_charset(None) # the test vector data is 7-bit clean
     del sigpart['MIME-Version'] # MIME-Version on subparts is meaningless
     del sigpart['Content-Transfer-Encoding'] # ASCII-armored PGP Signature data is 7-bit clean
     return sigpart
@@ -197,6 +208,9 @@ OpenPGP Example Corp''')
                 msg[h] = payload[h]
     return msg
 
+def cleanpart(part:email.message.MIMEPart):
+    del part['MIME-Version'] # MIME-Version on subparts is meaningless
+    del part['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
 
 def make_payload(multipart:bool=False):
     payload:email.message.MIMEPart = email.message.MIMEPart()
@@ -225,11 +239,73 @@ OpenPGP Example Corp'''
     if not multipart:
         payload.set_content(txt)
         payload.set_type('text/plain')
-        payload.set_charset('us-ascii') # the test vector data is 7-bit clean
-        del payload['MIME-Version'] # MIME-Version on subparts is meaningless
-        del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+        payload.set_charset('us-ascii')
+        cleanpart(payload)
     else:
-        raise NotImplementedError("need to get to multipart")
+        html = f'''<html><head></head><body><p>Hi Bob!
+</p><p>
+I just signed the contract with BarCorp and they've set us up with an account on their system for testing.
+</p><p>
+The account information is:
+</p><dl>
+<dt>Site</dt><dd><a href="https://barcorp.example/">https://barcorp.example/</a></dd>
+<dt>Username</dt><dd><tt>examplecorptest</tt></dd>
+<dt>Password</dt><dd>correct-horse-battery-staple</dd>
+</dl><p>
+Please get the account set up and apply the test harness.
+</p><p>
+Let me know when you've got some results.
+</p><p>
+Thanks, Alice<br/>
+{dotsig_separator}<br/>
+Alice Lovelace<br/>
+President<br/>
+OpenPGP Example Corp<br/>
+</p></body></html>'''
+        attachment = f'''diff -ruN a/testharness.cfg b/testharness.cfg
+--- a/testharness.cfg	2019-10-21 06:51:43.732780407 -0700
++++ b/testharness.cfg	2019-10-21 06:51:39.016767239 -0700
+@@ -13,3 +13,8 @@
+ endpoint = https://openpgp.example/test/
+ username = testuser
+ password = MJVMZlHR75mILg
++
++[barcorp]
++endpoint = https://barcorp.example/
++username = examplecorptest
++password = correct-horse-battery-staple
+'''
+        txtpart:email.message.MIMEPart = email.message.MIMEPart()
+        txtpart.set_content(txt)
+        txtpart.set_type('text/plain')
+        txtpart.set_charset('us-ascii')
+        cleanpart(txtpart)
+
+        htmlpart:email.message.MIMEPart = email.message.MIMEPart()
+        htmlpart.set_content(html)
+        htmlpart.set_type('text/html')
+        htmlpart.set_charset('us-ascii')
+        cleanpart(htmlpart)
+
+        altpart:email.message.MIMEPart = email.message.MIMEPart()
+        altpart.set_type('multipart/alternative')
+        altpart.set_boundary(hashlib.sha256('multipart-alternative'.encode()).hexdigest()[:10])
+        cleanpart(altpart)
+        altpart.attach(txtpart)
+        altpart.attach(htmlpart)
+        
+        attachmentpart:email.message.MIMEPart = email.message.MIMEPart()
+        attachmentpart.set_content(attachment)
+        attachmentpart.set_type('text/x-diff')
+        attachmentpart.set_charset('us-ascii')
+        cleanpart(attachmentpart)
+        attachmentpart['Content-Disposition'] = 'inline; filename="testharness-config.diff"'
+        
+        payload.set_type('multipart/mixed')
+        payload.set_boundary(hashlib.sha256('multipart-mixed'.encode()).hexdigest()[:10])
+        cleanpart(payload)
+        payload.attach(altpart)
+        payload.attach(attachmentpart)
     return payload
 
 def signed_encrypted(msgid:str, params):
@@ -246,7 +322,7 @@ def signed_encrypted(msgid:str, params):
     rcvdstring = rcvd.strftime('%a, %d %b %Y %T %z (%Z)').strip()
 
     # make the Cryptographic Payload:
-    payload = make_payload(False)
+    payload = make_payload(params['multipart'])
 
     subj = 'BarCorp contract signed, let\'s go!'
 
@@ -309,14 +385,14 @@ def signed_encrypted(msgid:str, params):
     encpart = email.message.MIMEPart()
     encpart.set_content(str(encmsg))
     encpart.set_type('application/octet-stream')
-    encpart.set_charset('us-ascii') # encrypted body is ASCII-armored already
+    encpart.set_charset(None) # encrypted body is ASCII-armored already
     del encpart['MIME-Version'] # MIME-Version on subparts is meaningless
     del encpart['Content-Transfer-Encoding'] # ASCII-armored data is 7-bit clean
 
     cruft = email.message.MIMEPart()
     cruft.set_content('Version: 1')
     cruft.set_type('application/pgp-encrypted')
-    cruft.set_charset('us-ascii') # the cruft data is 7-bit clean by definition
+    cruft.set_charset(None) # the cruft data is 7-bit clean by definition
     del cruft['MIME-Version'] # MIME-Version on subparts is meaningless
     del cruft['Content-Transfer-Encoding'] # the cruft data is 7-bit clean by definition
     

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -245,7 +245,7 @@ def signed_encrypted(legacy=False, multilayer=False, multipart_payload=False):
         innerpayload = payload
         payload = email.message.MIMEPart()
         payload.set_type('multipart/mixed')
-        del legacydisplay['MIME-Version'] # MIME-Version on subparts is meaningless
+        del payload['MIME-Version'] # MIME-Version on subparts is meaningless
         # arbitrary fixed boundary for replicability:
         payload.set_boundary(hashlib.sha256('legacy-wrapper'.encode()).hexdigest()[:10])
         payload.attach(legacydisplay)

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -24,7 +24,9 @@ where SUBCMD is one of:
   help
   sign
   sign+encrypt
-  sign+encrypt+legacy''', file=to)
+  sign+encrypt+legacy
+  multilayer
+  multilayer+legacy''', file=to)
 
 # We want maxheaderlen=72 here so that the example fits nicely
 # in an Internet Draft.  But it is risky -- i think it could
@@ -168,7 +170,7 @@ OpenPGP Example Corp''')
     return msg
 
 
-def signed_encrypted(legacy=False):
+def signed_encrypted(legacy=False, multilayer=False):
     # seconds since the unix epoch
     posixtime = 1571667491
     # America/Los_Angeles during DST:
@@ -211,14 +213,17 @@ OpenPGP Example Corp''')
 
     subj = 'BarCorp contract signed, let\'s go!'
 
-    msgid_rider = ''
-    # never do this! we only do it for a repeatable session key:
-    sessionkey = b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2'
+    # index by [legacy][multilayer]:
+    cfg = {False: {False: {'sk': b'8df4b2d27d5637138ac6de46415661be0bd01ed12ecf8c1db22a33cf3ede82f2',
+                           'msgid': 'signed+encrypted' },
+                   True: {'sk': b'5e67165ed1516333daeba32044f88fd75d4a9485a563d14705e41d31fb61a9e9',
+                          'msgid': 'multilayer'}},
+           True: {False: {'sk': b'95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e',
+                          'msgid': 'signed+encrypted+legacy-display'},
+                  True: {'sk': b'b346a2a50fa0cf62895b74e8c0d2ad9e3ee1f02b5d564c77d879caaee7a0aa70',
+                         'msgid': 'multilayer+legacy-display'}}}
 
     if legacy:
-        sessionkey = b'95a71b0e344cce43a4dd52c5fd01deec5118290bfd0792a8a733c653a12d223e'
-        msgid_rider = '+legacy-display'
-
         legacydisplay = email.message.MIMEPart()
         legacydisplay.set_content(f'Subject: {subj}\n')
         legacydisplay.set_type('text/rfc822-headers')
@@ -243,12 +248,32 @@ OpenPGP Example Corp''')
     payload['Date'] = whenstring
     payload['Subject'] = subj
 
-    sessionkey = codecs.decode(sessionkey, 'hex')
-    payload['Message-ID'] = f'<signed+encrypted{msgid_rider}@protected-headers.example>'
-    payloadmsg = pgpy.PGPMessage.new(str(payload), format='m')
-    # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
-    # in order for the signature creation time to match the message Date header:
-    payloadmsg |= alice_key.sign(payloadmsg, created=when)
+    sessionkey = codecs.decode(cfg[legacy][multilayer]['sk'], 'hex')
+    payload['Message-ID'] = f"<{cfg[legacy][multilayer]['msgid']}@protected-headers.example>"
+
+    if multilayer:
+        # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
+        # in order for the signature creation time to match the message Date header:
+        pgpsig = alice_key.sign(pgpy.PGPMessage.new(str(payload), cleartext=True), created=when)
+        sigpart = getsigpart(pgpsig)
+
+        sigwrapper = email.message.MIMEPart()
+        sigwrapper.set_type('multipart/signed')
+        del sigwrapper['MIME-Version'] # MIME-Version on subparts is meaningless
+        del sigwrapper['Content-Transfer-Encoding'] # test data is all 7-bit clean
+        sigwrapper.set_boundary(hashlib.sha256(f"inner{payload['Message-ID']}".encode()).hexdigest()[:10])
+        sigwrapper.set_param('protocol', 'application/pgp-signature')
+        sigwrapper.set_param('micalg', f'pgp-{pgpsig.hash_algorithm.name.lower()}')
+        sigwrapper.attach(payload)
+        sigwrapper.attach(sigpart)
+
+        payloadmsg = pgpy.PGPMessage.new(str(sigwrapper), format='m')
+    else:
+        payloadmsg = pgpy.PGPMessage.new(str(payload), format='m')
+        # Note that https://github.com/SecurityInnovation/PGPy/issues/291 needs to be fixed
+        # in order for the signature creation time to match the message Date header:
+        payloadmsg |= alice_key.sign(payloadmsg, created=when)
+
     cipher = pgpy.constants.SymmetricKeyAlgorithm.AES256
 
     encmsg = alice_key.pubkey.encrypt(payloadmsg, cipher=cipher, sessionkey=sessionkey)
@@ -297,9 +322,13 @@ if __name__ == '__main__':
     elif sys.argv[1] == 'sign':
         print(signed().as_string(maxheaderlen=MAXHEADERLEN))
     elif sys.argv[1] == 'sign+encrypt':
-        print(signed_encrypted(False).as_string(maxheaderlen=MAXHEADERLEN))
+        print(signed_encrypted(False, False).as_string(maxheaderlen=MAXHEADERLEN))
     elif sys.argv[1] == 'sign+encrypt+legacy':
-        print(signed_encrypted(True).as_string(maxheaderlen=MAXHEADERLEN))
+        print(signed_encrypted(True, False).as_string(maxheaderlen=MAXHEADERLEN))
+    elif sys.argv[1] == 'multilayer':
+        print(signed_encrypted(False, True).as_string(maxheaderlen=MAXHEADERLEN))
+    elif sys.argv[1] == 'multilayer+legacy':
+        print(signed_encrypted(True, True).as_string(maxheaderlen=MAXHEADERLEN))
     else:
         print(f'Unknown argument "{sys.argv[1]}"', file=sys.stderr)
         usage(to=sys.stderr)

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -170,23 +170,10 @@ OpenPGP Example Corp''')
     return msg
 
 
-def signed_encrypted(legacy=False, multilayer=False):
-    # seconds since the unix epoch
-    posixtime = 1571667491
-    # America/Los_Angeles during DST:
-    tz = datetime.timezone(datetime.timedelta(hours=-7))
-    # 2019-10-21T07:18:11-0700
-    when = datetime.datetime.fromtimestamp(posixtime, tz)
-    whenstring = when.strftime('%a, %d %b %Y %T %z').strip()
-
-    # message was received 28 seconds after it was generated:
-    rcvd = datetime.datetime.fromtimestamp(posixtime + 28, tz)
-    rcvdstring = rcvd.strftime('%a, %d %b %Y %T %z (%Z)').strip()
-
-    # make the Cryptographic Payload:
-    payload = email.message.MIMEPart()
+def make_payload(multipart:bool=False):
+    payload:email.message.MIMEPart = email.message.MIMEPart()
     dotsig_separator = '-- ' # this is a totally different kind of "signature"
-    payload.set_content(f'''Hi Bob!
+    txt = f'''Hi Bob!
 
 I just signed the contract with BarCorp and they've set us up with an account
 on their system for testing.
@@ -205,11 +192,33 @@ Thanks, Alice
 {dotsig_separator}
 Alice Lovelace
 President
-OpenPGP Example Corp''')
-    payload.set_type('text/plain')
-    payload.set_charset('us-ascii') # the test vector data is 7-bit clean
-    del payload['MIME-Version'] # MIME-Version on subparts is meaningless
-    del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+OpenPGP Example Corp'''
+
+    if not multipart:
+        payload.set_content(txt)
+        payload.set_type('text/plain')
+        payload.set_charset('us-ascii') # the test vector data is 7-bit clean
+        del payload['MIME-Version'] # MIME-Version on subparts is meaningless
+        del payload['Content-Transfer-Encoding'] # the test vector data is 7-bit clean
+    else:
+        raise NotImplementedError("need to get to multipart")
+    return payload
+
+def signed_encrypted(legacy=False, multilayer=False, multipart_payload=False):
+    # seconds since the unix epoch
+    posixtime = 1571667491
+    # America/Los_Angeles during DST:
+    tz = datetime.timezone(datetime.timedelta(hours=-7))
+    # 2019-10-21T07:18:11-0700
+    when = datetime.datetime.fromtimestamp(posixtime, tz)
+    whenstring = when.strftime('%a, %d %b %Y %T %z').strip()
+
+    # message was received 28 seconds after it was generated:
+    rcvd = datetime.datetime.fromtimestamp(posixtime + 28, tz)
+    rcvdstring = rcvd.strftime('%a, %d %b %Y %T %z (%Z)').strip()
+
+    # make the Cryptographic Payload:
+    payload = make_payload(multipart_payload)
 
     subj = 'BarCorp contract signed, let\'s go!'
 

--- a/generate-test-vectors
+++ b/generate-test-vectors
@@ -65,6 +65,7 @@ def usage(to=sys.stdout):
     print(f'''Usage: {sys.argv[0]} SUBCMD
 where SUBCMD is one of:
   help
+  list-vectors
   {subcmds}''', file=to)
 
 # We want maxheaderlen=72 here so that the example fits nicely
@@ -429,6 +430,9 @@ if __name__ == '__main__':
         else:
             msg = signed_encrypted(sys.argv[1], params)
         print(msg.as_string(maxheaderlen=MAXHEADERLEN))
+    elif sys.argv[1] == 'list-vectors':
+        for vector in cfg:
+            print(vector)
     else:
         print(f'Unknown argument "{sys.argv[1]}"', file=sys.stderr)
         usage(to=sys.stderr)

--- a/multilayer+legacy-display.eml
+++ b/multilayer+legacy-display.eml
@@ -1,0 +1,54 @@
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="750bb87f7c";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <multilayer+legacy-display@protected-headers.example>
+Subject: ...
+
+--750bb87f7c
+content-type: application/pgp-encrypted
+
+Version: 1
+
+--750bb87f7c
+content-type: application/octet-stream
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdAQL6ivBlSduqtPTk/Y3+ijcQ+N5NYfDl+o474FT/BUBIw
+iZzmY+CQgrHf2iRPm2GuOoN+XuZtFYk4cIhwe0gAK7+p/44osZGipnzcw0NDbMC3
+wcDMA3wvqk35PDeyAQwAtPLguH2X/uqQupJWoF5bnpcxogM2hr+7W5FSFNCiTh6L
+ZWYY9B1M+qQqOsTSqpA9mhOoqlnUGiRWYFU164mla3KmMu4rDKSrP761E9ozQl4k
+o7+xjvWEBsVeU6KZLPpi9r5KDxwiGO8PT7qsNHv+OTSvJbOv1azLcSo4g67J03uU
+rSbMDjPD1BAZDyf7TwKpg4MXVmJtnuHURjzIQ/VtS6eZ0FYzvPZX0rMo00G4bNkR
+t1w06hEUemFRtEI/JhD8H3hDkx4Xo/XBWuiVD/UWrlXh1rGjTCfezd4p7F74/+t+
+VHxLWWkyeNXnQqFZX6nIclvoW/ZQr2RycA8j7L/BSYEeINxE4gau+Mh/9IN460G5
+Aabjok1FIv8D3inMDI9MgxHYOkAReCMJ4btObtLlzQy+f6aE3BPihIvAYlRzCBel
+9Cl604BDGmVug+UeYJ7+1S55HB5vbWzx88IwELw4FCFaYwiK2FOB53tXSc/sGkBQ
+Eh7hf2RLSq0c17fMBuNa0sKDAY5PKwukRG+RDz/TeM0e2Y42hPsVm6rOPKNIjygd
+oGHLfXw/vYtpxVcdipa9LRAnoJ4JNSaB3vOLz54yxeXuOJrg6nT9JvSRuQ1AlZHq
+7Sf2i0kbYkNYZOig54PVJ1/ESkzyrNlmxlRrmo/I9tCr7Wa5bMlgh0S7wm5wPUm4
+sEEf+WeqU9cAQKGz4gmY87/ErvPUnudcl21SKyFZ6SlgXdo1GEAUagf3YPL/eOaW
+KSG/c69L3K2nBr8NnsTH054AokKOEJKM0+Tu+z8dSRFfa8vJt+fbaV/wL3xK9yEQ
+KxJurGTCQ3uKyaeVEyyc5oscv005iaaS9cskkU2eArjAoXNcS7dFMuNXJBbn9WZc
+vDmlUSnpob6ZEVySNiQLKyVPsd50VQALv9ySsVT/LNx1N+QR4PSg7uX029itcXbp
+zuJgBg8hnpZxKD1vWPzWslmyaC6iS4Q0qiD4XL669NEmtrSpXjX1xFv5SGLWO7IE
+TQttUOUgH2tarrFESGOV+354h8kW/CewMO3yR/rTV19HsZfBbuzCLMiURPmK51gb
+diZCD9mxd+LPuMPKo0nnoKgloFMgiono9bimJonGNKdfwhoRFFP8tIHZhkue9zqb
+AnjZazfsI6YyfGsshfjQ2xHUuT8tTXtNCA/yhhld3yp1b2LfWdWdGxcGrVugFhy3
+fUBgeiL2cIf09cn10Y19cIISwa++LpkVWLWuINORu+d2z5Yi9E2I3Tqoi7kt3PvA
+GVfKK+Vpytf5f19vm53gfYPGHeF+V9fLZq2JrD4ewSzHSzbSf0Lo2uIUCRv9gTXV
+scKiRvA7O0tjQHKFQKcrZLcUd1YE3uRcLqL4GMlHZMdRIQ2SfEvZe8Ad5ZxoacTW
+nthYxDipYMheaLmXmePyTGXV0yo/btUe9q0vErhxIrWxnonhQxronVR2go9695Ia
+w/b1FdihjhBvVmymHdYXxCsbIKIPsE7MeAt0YXEmOly2MsqlbYv+XVwFpw9gYa6E
+QwMRS3Kd1bJgpuqZ4nOnHgZ1Qewhi1WbF9M3Kz6EryAgQJ6Sgy7syHqdYh4MzVOE
++VMThZ5Q92DIQcJsPpEKpDIfnbEYm7N6Icfmz6fj1L9s7X1oew==
+=KH2Q
+-----END PGP MESSAGE-----
+
+--750bb87f7c--
+

--- a/multilayer.eml
+++ b/multilayer.eml
@@ -1,0 +1,53 @@
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="15d01ebd43";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <multilayer@protected-headers.example>
+Subject: ...
+
+--15d01ebd43
+content-type: application/pgp-encrypted
+
+Version: 1
+
+--15d01ebd43
+content-type: application/octet-stream
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdArQ8apKY0ciE47ZyBKgbOditGO6OBizW/VeQItRdCxA0w
+KaoRJewLgRnuvwaEisHWjiA0IHB9+0BSja+GFIh6gBWCFqzAfJQxoywAZMHznn6k
+wcDMA3wvqk35PDeyAQv/X3CYHUgNH81gAKZK/Cb7+WDbjmHcgskkvtceANQbEBEr
+/yVoou5BSlXsEni2wn1dtrIsrkhj6OF+B1mwGELw/3qcXdhT46iIrjn547b8Wycp
+saey8JqqX8FdfrxEYyOeBJn9CMDm0Dawfv+kNEdbfZtZ2IUONRgigKfcs+Pvrv3e
+hoY3KUe47cbiqKvw11VFTu2e4+rIPXW4sB3/95Epvo+RSo58p62kbvJDmBPt5E06
+mEykcvyd6GP0eyTTbtaHNcNWd8jvGUobfikwibADcmjXmbPwTJefMCBbsYov86bK
+72QOWbp39JcmwUWdo850+sU0XoCHmqditFfZqEdcKRFJOl+Rt+pMSrDixHb8Thdi
+WcxUXetpDvACrmjsipKHbxBZAgEU0K71zvbUPk930jOqJgsyXKX0WI8u32gNZDfc
+enHAAnALKvwoTGU3EM6do0XRMUKYL6+ON1F1L9S1Rm9Fa+WQKcO04ZvdeHbQXkt3
+Fx6ZvZT/Bn3fcIWBpHfs0sI0AfeSpGjSejaZvZQ8qoOTQkOqrjuRnpU8232/ngsC
+46mObydGJZ5qEMnmdDOfQB6L1LR9dQTCzA6swlG4U62MoO0n6yILCxLZTPVKYm7c
+6r4KnQcvrGk1pgozdW1QjFBOjiDXbitHnqGorxKUcVVorXSEU919wKm11tGGyZ7/
+2sta4WQq9ILVvPqB2I1hLfbteBUYWgB/rJcc6JsZyRItEKjSSXZoanYyuCPf0m5r
+rpzf18kz8gYk92RTLzefALgMiIuU9CXFtd673/MalsZ2DRYjnI3tC9AXEdV9yVVa
+KYX/ECbFPHNxxulu/HU7hL7QQbgxA1E41RM2KjEzmwUEA8EomuNN7eQ5AJjDP0qk
+EIjIxIsW8at8FB4vB4sxh95OiF3hHFZj8q6/VZW8K8LspERCdrKmtu46xt2g7uKx
+8ifdwqMT5OPu4VD5EPuOZLJRnSnYskTBwjZnX+ZqRdz/7z7XdUhvn4CjjiFt804a
+4uunVgTeVXQay97a7oz+SCrNc+Gvv7K0dt7oUt512+0hQAJ3W9J3Chlht4UKs759
+QymPx4smS8kY7c57OWpab481cqeQZLMIftBconhzSzAGl1LZhc5MVoc7l3dEABcx
+G+zcTIiRT+io8PwaBvnUg3nE0xP201s5vpK2vbBBMDh3O3titYMBDJp3riyp81AR
+Rm6tymUZaRMxq17T6BJ0b0fXyQ2fiz5vuudK5L/zDBvkOSIlhvaV2zxJqMhlSS54
+W2RrwNjxkgBCiz1u1Yzi/HQ+jUwO/p8uGn0hyyIEEDIX50gPe2IQjgEjGteIBrDF
+sfi9jCEhK/Y0xANG4Mt01Ukt6cgGQhrKuBnyy9KRG+US7aaPdMQuPLfOlhPZOjIQ
+Bytek3JyT/QCsKPSjcGiNinllYk+Za8gL6SCNfZam1y/E802xX4z30t7Z6EBSRLi
++qwzOCu7wTkJkoOPLfZFLY41OrVaR8lyBG1eZmtJXbER1GuuRv/7IC2xcDZv/2VO
+ahdnPLy7
+=rOD1
+-----END PGP MESSAGE-----
+
+--15d01ebd43--
+

--- a/signed+encrypted+legacy-display.eml
+++ b/signed+encrypted+legacy-display.eml
@@ -1,0 +1,53 @@
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="73c8655345";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <signed+encrypted+legacy-display@protected-headers.example>
+Subject: ...
+
+--73c8655345
+content-type: application/pgp-encrypted
+
+Version: 1
+
+--73c8655345
+content-type: application/octet-stream
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdAS0G0tRGi0cGe2INISDT7xS8b5e1iezXzXuFOrAa1fWgw
+JK32KLaTpnHegkEVB/cdMLMEEq56BkktxtC94YNSoeKJOTmNPhR+YWLruWRmZoAk
+wcDMA3wvqk35PDeyAQv6Ag30fne2jVFaH+oStUEoX/BEaclWJfpIgu9Ex5SYLmEg
+tNHJtLMbKWYKQHhpMiyONeVvfgkus8cPZMtpc+eZEP9FaEdQ69CqkB9Cmqt4Hs2q
+yNk14ec0KtL9/b5IPx4rVBrBuFSqxxiS0r0bMsTvKss1p4UGgPN9UPhJSj4dsmDP
+w+gLkxsUKL6i37QJIOmarMawS4iK7/MN+GbjzlMduw/VuLV80DYgIt4l96E9xJ+1
+u7S6/TKXyUSuxG1Wo+3tCEpy+hTKeS8mYnjD8OYVF5To+TCMnznCiEEwebd44ild
+54Bt4QS/G+x/s/aSFRM8pN2O8qz5D5sy+Mzp4dG6w/9fAhIt9mp8W/6Vn+Cgy8kD
+0dHy3pN5dVavmsBqzy0uaf4xAoLLJZQBzyR+0UWygUyfc2N6VHkXo+S30LhSfkJO
+BMNKqkCaUoLFlHQLstZXETfXMJzpuUySH99ZTeyVnfB/eiEr9CByQqTeN9Uqtu0R
+QYWEpTvvYei/vJCNDBqT0sIxAftxmF/H2K4hCW2qD3eE/zSe2PpabgStHmfdZrcx
+X1sdOYZ7nOE0L3J/zE3jASEyQUZHr5rdt/RI5qwD2a7zirp8RNAyvk93InQuseX7
+mgHADtk9LdNTWumiUd8pvm/ChXoRKvqjSV7mHpdBil0D4JKpZTGAQieP4fF71IYw
+4E+VwiZZKIDSiYMUEljA3U7+M9siELlvKRACrrPZKr6OE58JywlIgRdewzroMWIO
+HoNJ4EOzij5rJfd6fAF4A3lH3wRu8dcuqrKwK2DhL+as1Zc/AABZD9Ov8t97/A/t
+b6jWJqVAVWilgarv9wwI4icN6q9hdwPZF5OaLgvpskGAtG3z51vkJuAiMogWP2Iv
+T0GuamZb5177yH5ShtowlTZN6D5WR7ShYbdHAPKRWFcYz4S9b7UZiWH1Ts2lHglJ
+5mUbpTI1EvJFO1nwUcVLTuqB2N7lwVvD0oM9lSDcgUmrS04lqBDEax1V+PoKXYAi
+Q0z3eH6EDzw0xYWZhiBjgvor2qmGuIEqjBa+5qIOMrzBZK+7y0KOlkgaPik0BeYB
+jC/107Us+5i7c3EfQXj4K5XP72/SR0KC9cr//q9tRBOGki8yVicyOGbtSGsNgul/
+5T0VlrTecw+3ZOH4mQRGCJmxkes1amdDeklISfBeOe+LBx/tjkyixeXeh05i1doy
+n9VY/utOqu3Oo6XnTWktxajuhfvwSA2wNB/JnRFqu8QEVmqVzD/jwNvsvETQC83j
+GPKYo+P1PpAHeqRs4tMq18JQzzytXzr5llLp26qT4Sgul+8tqafkfS6zGL1xShMQ
+V1uMtoAt5KBfO4nfiGUAiZeR2RqRrT4YLHEZvpblIE8y7l3y8WV8gdiFfOXZ21mg
+gGntqnxU0hrC0IggGVBBY7zHVrcQxJOGsnAsqhQJpVBSnP0YgyrKCEVgDF4ibPBz
+y2bRxKP4es0advuEVKGAHULhzoV26Siz8h9MkeI6o+d28vestHng++2DsmCrdpSv
+EatA
+=MxXQ
+-----END PGP MESSAGE-----
+
+--73c8655345--
+

--- a/signed+encrypted.eml
+++ b/signed+encrypted.eml
@@ -1,0 +1,51 @@
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="bcde3ce988";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <signed+encrypted@protected-headers.example>
+Subject: ...
+
+--bcde3ce988
+content-type: application/pgp-encrypted
+
+Version: 1
+
+--bcde3ce988
+content-type: application/octet-stream
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdAk4rw/q9TK6dtIBm42jF6Z7z34KmNIDAKF4v4f09n5l0w
+OAgtdmIHyUu3ZOHSb8cFRbjAGQ3RcgIAe4DdsZIy/m9eLEDXEzf9yMSufBtap6xb
+wcDMA3wvqk35PDeyAQwAgFIzERxgt1aZlcA29Ds10pv0Y3oZ5yKvMNxd+WEEZNcT
+rJBOFNlhek5/9/nkATGiDBaKOsu5o9VyDfKMAV0TYwZxuMgUNtvVpf0XL21dghYt
+KVqEHeOTXzprUBdztG4Lp4e0vsG0jPZS+CvTLjbcvO+/lzb314mwN8s8vZiQ7Vlj
+DxubIqKypY3jL66U0Acwk85IsXdK4CB4nousr2JFK3Y3zv7cQBtPKHEG8HkmvT0R
+tl0QoAkdHfw0q4rpc6183FA9e8EUV88XRJrKIYn86IaTPuMkp8ULWSsboalkJH3J
+rSq8kzAFFd/A6G8wSj/hVpH6U+NBGW3Z/DQnRmwHqSJfu/Tnue6TFLdDN1EYzk/L
+Nlr4YsH6eIB8v3H4u6kY/SwhHCv/F0jItHYVSsIeJz81L0vh28H6hLIMvSDFofJP
+fBgIJfZIJ8nzgFpLphVpk0mcI7jHElxEPRg/M5Lmlav9srYHbKbJ0LT67Z9AFnZB
+LHRa/p1eZnjpTxrYU2qZ0sHaAS0MB1TwpiucDRH2VN1z8vSKb1qizJ6ZH3qT3zQ8
+EAf6Lar5B6l3v/WwhjMPgu/pLlvZgDAo0cWkBYqzWpOcwviAeC7OwqnZY9/BFm/F
+RefFysUIu7fWpvBbKtdch9lhb3baetWKI9uAwsaublwgSGZ4dBR2hfVaX72/8oDW
+3oJoUvlw59J1r5Ai1l1YtyU8ctNGT2CqbKp6OgVzqm8BOhyQS1ayjMNU0VJs0s3N
+BJ0B1rctk5QykDAu3rVf+sgyqzQ7ohFqlG0W/7haocAQqW++Wy9PW/n0oNAuwugv
+W4zisCSB916z7whso00e1Ee3Fl7xgubzrGCHU3JNO5X73+gQHZ+jzuyGdBM5NTxd
+UcT89ekkd9XqfR2kJrhgiUOe15znWks5JB6VGKWfz2kp2wu1AVxSkbii1Qk/tRhX
+PUpHGwkin41WCPlUFA6xMLk9RmLjer2Wkg9zYosnzEIHdPj+WisWY86NRSZ/tJiw
+qZvzNwIgkzvqs1T/8aU5Z5rUOqI1l0Kd+tVjlkPyLrZOrvEeYwOwbAzlCdLxsCdq
+pY4ckpU/kMbfXXk21YWYFKDCopT7iRkuzDYlyGN4w/LPKQCMZrQxSms9uPNU5XG7
+Au4yYdZVMkCLuLQ0kktuLe/CCX4bX82eF/AJ5DEFxWB3CT8FbVhdKrQ2RrLKwE7b
+0jBdmT3NoJMtCbq68TBJO3MmOu6AaW7cD4INREbiD+Vr8ukqsnWkFiJ3NigQiT/4
+PppJ2bAABRy9Gloa434PN3zgoWzmv80EfyNbZNfY7nGAOhAzBs8FqhrOY2WIBTp+
+YEkvEjS5YOwgEj1/zcHts1pOWczY/AfVi2sLkCT8FqsNlfPPebdR4Oq+CEav/M52
+A+CS0s7j1gklNfNd
+=87qA
+-----END PGP MESSAGE-----
+
+--bcde3ce988--
+

--- a/signed.eml
+++ b/signed.eml
@@ -1,0 +1,42 @@
+Received: from localhost (localhost [127.0.0.1]);
+ Sun, 20 Oct 2019 09:18:28 -0400 (UTC-04:00)
+MIME-Version: 1.0
+Content-Type: multipart/signed; boundary="904b809781";
+ protocol="application/pgp-signature"; micalg="pgp-sha512"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Sun, 20 Oct 2019 09:18:11 -0400
+Subject: The FooCorp contract
+Message-ID: <signed-only@protected-headers.example>
+
+--904b809781
+Content-Type: text/plain; charset="us-ascii"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Sun, 20 Oct 2019 09:18:11 -0400
+Subject: The FooCorp contract
+Message-ID: <signed-only@protected-headers.example>
+
+Bob, we need to cancel this contract.
+
+Please start the necessary processes to make that happen today.
+
+Thanks, Alice
+-- 
+Alice Lovelace
+President
+OpenPGP Example Corp
+
+--904b809781
+content-type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+
+wnUEARYKAB0FAl2sXpMWIQTrhbtfozp14V6UTmPyMVUMT0fjjgAKCRDyMVUMT0fj
+jjvKAPwOVIBTcSVKcji7kBw0ljyBwpOgoQ7UGaY6cINfhGg5HAEA4jjbHaEuGZ29
+WDTKxW/exLlcW1WqY0fva3t6jbniyQI=
+=IsHn
+-----END PGP SIGNATURE-----
+
+--904b809781--
+

--- a/unfortunately-complex.eml
+++ b/unfortunately-complex.eml
@@ -1,0 +1,62 @@
+Received: from localhost (localhost [127.0.0.1]);
+ Mon, 21 Oct 2019 07:18:39 -0700 (UTC-07:00)
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; boundary="241c1d8182";
+ protocol="application/pgp-encrypted"
+From: Alice Lovelace <alice@openpgp.example>
+To: Bob Babbage <bob@openpgp.example>
+Date: Mon, 21 Oct 2019 07:18:11 -0700
+Message-ID: <unfortunately-complex@protected-headers.example>
+Subject: ...
+
+--241c1d8182
+content-type: application/pgp-encrypted
+
+Version: 1
+
+--241c1d8182
+content-type: application/octet-stream
+
+-----BEGIN PGP MESSAGE-----
+
+wV4DR2b2udXyHrYSAQdA37iUGeDF69AyF+xJDY2wT55y895NJJZoj04a8WUhDC0w
+XdphqqDGeb/nGjgKyaARHwK5dw+oj2Z1jbBveBJMRtPw+HHnUUsDUHOSaRvmIf0c
+wcDMA3wvqk35PDeyAQwAq2uqlZmQDTWCu/X1s08BoqyjpQ+ESOvqyVTYKBOklxlw
+fd2Eb3rIbPy3OkvMRKKpa1ZpGGXnButyTSz0h6+GJNoLQPN3jebYZCyEew+EIaAd
+ombr842DOR13QbM17+piWrFQR7KwQiFy/bbWrRT0QcExif8pXjUyTADR41GAMIbU
+D3d0u7M6XwQ2kAeuP0QUN/DSAdGGPCSS01DvNupFZe7/IfrMJq5r+s7SOj31QC0x
+CrbbwvzFR3c64PNH9pRE9ub1pKQJClQfjvs41k/vk+SSPl7anw4S8dLu20YY5GHi
+p4z60X1YvqHkov/4USGj/dfHvAjx1AkXb5MDgPFqPNtoDr+iE8Bgsuhigbgb+V5H
+5GUNCnOwzJADVYHQhMq6dOcNoJiupkd3WjL9XVS7kiDywTlsM3olRYl/LWqw/tl7
+WiVlR3kkQVCdCahQlc/oMKe+R1Jkvtpo/oJJ/Vw16VEr23FSCQdjIBCKqD1i2Cn8
+GE84/wlBYfTPGmIm087c0sQHAS+FatV+LOXd58Z0BrgdXCouvNFJWthebn4FwS4u
+4axF26izNiJahS/nYwVtlrfFHG51v5qSlyYgQBAy33YLJ9hmiewFRXnLZc6kwrme
+Fx1ValiIo6O+7lgM0YIpOFtETHsLJWt7XsijwN21lXY29ebov9gTCriOOdT5heFD
+jmshm1WmOMyzG/FxrtRobiXqmBJbz/Jk+RIv716JYJRV55cZfIpKzqNkmVg73Rbz
+XLRmssI0SGpjwZcMx1fYFEKLGII+Oorhsj1BAw0RqRD9f7uIO2E7hsoQIBGQX5G+
+3FWLm90NLF879uHb8BWKlCJNbXRc6oSrwNTKgSRAhD+FS+WcR4MZde8rAbecZNLa
+6oSpG/+FHv43PHoj2CJqdbtvK42YbSeJ/fOaGAfa/nsxf4gn9rkBucW4Swi8mF5N
+lQKiz7vmgsowBuBShFWFCcXtWUfnj64nwX5JlX1fFbXhCENl4K1yiMhjb+p+v4pC
+SnINJKZKvhfrS8Xj/kKxw6UgTUpV9J/o7T7szudWITG3Sr94KjEIxYl4XQYqWzQ/
+HWgHWNIKsynqwLcC1WP53H3OlIkrDu9/takPm71J67Fj7uHxO6muiBA0Xfd44WCH
+DR6UqmLx+qwxfwrIHsx8Rp9D0oPH/AHexBJhR2eMKQU92TafQk+s5K7dYxTIVEUZ
+j+Z6/D3pXQ6WTkY21lIWDZMZhPpxTWxtELntUcQjTMh7s7vebgzVgER92PEHRUQq
+dRF2OS7ApOuaQ86yIT8lIT+oBdXeahj/X74xGAt/HDO2SboqiCKf8STiLlPhBeMg
+AJhk0vAWAx6+EyyODt/0ymynOMONmBZ2XRsxPIwRIwBIzbNBfE+czLlqjL5TeaJt
+OWsW+4bH8768djk9+/hwH/OOWJPit0vtr6ZVbcoXTDYUgTrRKa+PxnuLF1v3LoVl
+AvaBjF8bGRPd7kaB+8KceXZw2Kx5oeHdIWE77Azw2Yojf2+FhStHw/tjCOsoRICm
+uO6c91L1/lxX69iguoB9z5AXtJyQR7lRlUU02e9S9eiuJ0XYtCqpnheq9nLIqZ6f
+OePmnouHi4Y3ucUmDvA9TM1wdaGs1edKMhMc9pWgi7bo3lHYruesqogeqaSudMu8
+oKDT6uRjtounCZUUI3C+kBNGkLYwEDKtgjpccHf8zVQeDwsoiylu3RkCHVRQHYqC
+bFf8z+bgXxnRNRFYu/83OrmkYohgszCDdbXhuu6hYyXPnmwDi2wvAE5hNBYNDgld
+mhfVPqjpRdRDHCH6KM2oZY3YhugMcXMdBvtzKVmWcM2a6Mh8C+bwdaCOitFYY76U
+mmJHYZoZbMoLEencfR55j5V1SIPxKdkMWjMhx6wPD/HbsLIcjzVuGOTsueeYPLBu
+z60hNJ6sCfDRPW2B4BdVY72Ih/93Ji5IOtJyXpK+sD2QRLYpP8G4gbWMP6fpuEkn
+3Ry376htovmEjzdjHardtXMQQA0iF8vsa5hKrxOAlNpmbHENGfwMytDCIvBWhPnx
+W2LZYMZUED5e8KSNZ2A9pexfmE+Xx2OFEhDusVp4GaTovSoflgEdX/8vbv0CBmnJ
+0jqJ9ZcD68QSyEyqlxxQmcL2yHojs12S0mObrZo6yygDrgPVhStCbiY=
+=gwzz
+-----END PGP MESSAGE-----
+
+--241c1d8182--
+


### PR DESCRIPTION
This branch adds three more test vectors, all of which use a multilayer cryptographic envelope.
 * no legacy display, simple message body
 * legacy display, otherwise simple message body
 * legacy display, multipart/alternative message with additional attachment

This last test vector is an attempt to encourage implementers to grapple with a plausible structure, but one that is unfortunately complex.

This set of changes also splits out the generated documents from the markdown source and assembles the source from them piecemeal.  I did this because i realized that one small change to the test vector generation script could mean a change in multiple examples, and i didn't want to have to do a lot of manual cutting and pasting.

it's still pretty kludgy but it all assembles appropriately.

But please be warned, the test vectors that involve encryption are not reproducible due to vagaries of the OpenPGP encryption process and how PGPy implements it -- that's generally good -- encrypting data should not be deterministic! -- but it's a bit sad for deterministic example generation. :( please be cautious to avoid accidentally changes you might find to these files if you have not changed the test vector generation code.