### PR TITLE
MIME-Version is a structual header

### DIFF
--- a/draft-protected-headers.in.md
+++ b/draft-protected-headers.in.md
@@ -149,6 +149,8 @@ Note that no "user-facing" headers ({{user-facing-headers}}) are also "structura
 
 FIXME: are there any non-`Content-*` headers we should consider as structural?
 
+ - `MIME-Version`
+
 Protected Headers Summary
 =========================
 


### PR DESCRIPTION
MIME-Version is also a structural header, that should not be copied to signed/encrypted part.