### PR TITLE
re-route readers to LAMPS work

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Protected Headers for Cryptographic E-mail
 ==========================================
 
 This repository tracked an earlier version of what ended up becoming [draft-ietf-lamps-header-protection](https://datatracker.ietf.org/doc/draft-ietf-lamps-header-protection/).
-Please refer to that document for a well-vetted and standardized approach for heder protection for end-to-end cryptographically protected e-mail.
+Please refer to that document for a well-vetted and standardized approach for header protection for end-to-end cryptographically protected e-mail.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 Protected Headers for Cryptographic E-mail
 ==========================================
 
-This repository tracks the Internet Draft documenting shared experience in providing end-to-end cryptographic protection for e-mail headers.
-
-The formal published version of the draft is [hosted by the IETF](https://datatracker.ietf.org/doc/draft-autocrypt-lamps-protected-headers/).
-
-It is discussed in the [LAMPS working group](https://mailarchive.ietf.org/arch/browse/spasm/).
+This repository tracked an earlier version of what ended up becoming [draft-ietf-lamps-header-protection](https://datatracker.ietf.org/doc/draft-ietf-lamps-header-protection/).
+Please refer to that document for a well-vetted and standardized approach for heder protection for end-to-end cryptographically protected e-mail.


### PR DESCRIPTION
the LAMPS work is approaching RFC publication, and it should supercede this preliminary work, as noted in #30.

I'm proposing to change the README here to point to the right place.  If there are no objections, we can merge this (and maybe archive this repo too).